### PR TITLE
Move logic ensuring enhanceModelWithRecommendations only done once

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -15,7 +15,7 @@ cds.on('compile.to.dbx', (model) => {
 });
 
 cds.on('compile.for.runtime', (model) => {
-	if (cds.cli.command !== 'build') enhanceModelWithRecommendations(model);
+	enhanceModelWithRecommendations(model);
 	enhanceModelWithEmbeddings(model);
 });
 cds.on('compile.to.edmx', (model) => {

--- a/lib/csn-enhancements/recommendations.js
+++ b/lib/csn-enhancements/recommendations.js
@@ -25,6 +25,7 @@ function enhanceModel(model) {
  */
 function enhanceEntity(name, model) {
 	const entity = model.definitions[name];
+	if (entity.elements['SAP_Recommendations']) return; // already enhanced
 	const vhFields = Object.keys(entity.elements).reduce((vhFields, ele) => {
 		// If the property has a value help
 		if (

--- a/lib/csn-enhancements/recommendations.js
+++ b/lib/csn-enhancements/recommendations.js
@@ -25,7 +25,7 @@ function enhanceModel(model) {
  */
 function enhanceEntity(name, model) {
 	const entity = model.definitions[name];
-	if (entity.elements['SAP_Recommendations']) return; // already enhanced
+	if (entity['@UI.Recommendations']) return; // already enhanced
 	const vhFields = Object.keys(entity.elements).reduce((vhFields, ele) => {
 		// If the property has a value help
 		if (


### PR DESCRIPTION
Remove check in compile.for.runtime, instead check if 'SAP_Recommendations' is already present in entity before enhancing it.
