### PR TITLE
chore: Update release.yml - node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
-    environment: npm
+    environment: npm:@cap-js/ai
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - name: get-version


### PR DESCRIPTION
Updated `node-version` to 24.
This change aligns with the most recent version of the template (regarding change https://github.com/cap-js/repository-template/commit/441e15ec324861e791b102646e28aae6c9b2d748) and is also required so that the npm version meets the requirement for trusted publishers (https://docs.npmjs.com/trusted-publishers).

### Have you...

- [ ] Added relevant entry to the change log?
