### PR TITLE
chore: Update release.yml - trusted publishing and step name added

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
   publish-npm:
     permissions:
       id-token: write
+      contents: write
+
     needs: test
     runs-on: ubuntu-latest
     environment: npm:@cap-js/ai

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
           NODE_VERSION: ${{ matrix.node-version }}
 
   publish-npm:
+    permissions:
+      id-token: write
     needs: test
     runs-on: ubuntu-latest
     environment: npm:@cap-js/ai
@@ -58,4 +60,5 @@ jobs:
         with:
           tag: "v${{ steps.package-version.outputs.current-version }}"
           body: "${{ steps.parse-changelog.outputs.body }}"
-      - run: npm publish --access public --provenance
+      - name: Publish package to npmjs.com
+        run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Added required permission for trusted publishing to npm. Added name to the publishing step.

Partial alignment with the template change https://github.com/cap-js/repository-template/pull/12.

References:
- Internal - https://wiki.one.int.sap/wiki/x/4xHKAAE
- https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow

### Have you...

- [ ] Added relevant entry to the change log?
