### PR TITLE
chore: update release env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
     needs: test
     runs-on: ubuntu-latest
-    environment: npm:@cap-js/ai
+    environment: npmjs:@cap-js/ai
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
# Fix Release Environment Name in GitHub Actions Workflow

### Chore

🔧 Corrected the environment name used in the `publish-npm` job of the release workflow.

### Changes

* `.github/workflows/release.yml`: Renamed the environment from `npm:@cap-js/ai` to `npmjs:@cap-js/ai` to match the correct GitHub environment name for npm publishing.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.33`

- File Content Strategy: Full file content
- Correlation ID: `3d92b3a8-c4a1-4674-982c-a31ed99773b6`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
