### PR TITLE
ci: Remove redundant checkout in action.yml

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -54,9 +54,6 @@ runs:
           fi
         done
 
-    - uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Use Node.js ${{ inputs.NODE_VERSION}}
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
# CI: Remove Redundant Checkout Step in Integration Tests Action

### Chore

🔧 Removed a redundant `actions/checkout` step from the integration tests composite action, as the repository checkout is already handled elsewhere in the workflow before this action is invoked.

### Changes

* `.github/actions/integration-tests/action.yml`: Removed the duplicate `actions/checkout@v5` step (with `ref` pinned to the PR head SHA or `github.sha`) that was unnecessarily re-checking out the repository during integration test runs.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.37`

- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `9e9ce4b2-2d3d-4d69-a53a-666edcd72152`
</details>
