### PR TITLE
fix: empty recommendations on active read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.0.0-alpha.1 - TBD
+## Version 1.0.1 - 2026-05-08
+
+### Fixed
+- Empty recommendations on read on active entities are returned empty to avoid UI errors
+
+## Version 1.0.0 - 2026-04-28
 
 ### Added
 - Out of box support for recommended values in field helps in Fiori UIs by providing an `SAP_Recommendations` navigation property in OData services which contains the recommendations.

--- a/lib/handlers/recommendations.js
+++ b/lib/handlers/recommendations.js
@@ -4,11 +4,27 @@ const LOG = cds.log('@cap-js/ai');
 export default function registerHandlersForRecommendations(srv) {
   srv.prepend(() =>
     srv.on('READ', async (req, next) => {
+      if (!req.target?.isDraft && req.target?.['@UI.Recommendations']) {
+        const recommendationsStruct = req.target?.['@UI.Recommendations']['='];
+        if (req.query.elements?.[recommendationsStruct]) {
+          const res = await next();
+          if (res) {
+            const response = Array.isArray(res) ? res : [res];
+            for (const row of response) {
+              if (row && !(recommendationsStruct in row)) {
+                row[recommendationsStruct] = null;
+              }
+            }
+          }
+          return res;
+        }
+      }
+
       // Recommendations annotation is missing on draft entity, thus req.target.actives
       if (
-        !req.target.isDraft ||
-        !req.target.actives['@UI.Recommendations'] ||
-        !req.query.elements[req.target['@UI.Recommendations']['=']] ||
+        !req.target?.isDraft ||
+        !req.target?.actives['@UI.Recommendations'] ||
+        !req.query?.elements[req.target['@UI.Recommendations']['=']] ||
         req._?.event === 'draftActivate'
       ) {
         return next();

--- a/lib/handlers/recommendations.js
+++ b/lib/handlers/recommendations.js
@@ -24,16 +24,16 @@ export default function registerHandlersForRecommendations(srv) {
       if (
         !req.target?.isDraft ||
         !req.target?.actives['@UI.Recommendations'] ||
-        !req.query?.elements[req.target['@UI.Recommendations']['=']] ||
+        !req.query?.elements[req.target?.['@UI.Recommendations']['=']] ||
         req._?.event === 'draftActivate'
       ) {
         return next();
       }
 
       const model = cds.context.model ?? cds.model;
-      const recommendationsStruct = req.target.actives['@UI.Recommendations']['='];
+      const recommendationsStruct = req.target?.actives['@UI.Recommendations']['='];
       const recommendationsDefinition =
-        model.definitions[req.target.actives.elements[recommendationsStruct].target];
+        model.definitions[req.target?.actives.elements[recommendationsStruct].target];
 
       const columns = Object.keys(req.target.actives.elements).filter(
         (ele) =>
@@ -41,12 +41,12 @@ export default function registerHandlersForRecommendations(srv) {
           ele !== 'modifiedBy' &&
           ele !== 'createdAt' &&
           ele !== 'createdBy' &&
-          req.target.actives.elements[ele].type !== 'cds.LargeBinary' &&
-          req.target.actives.elements[ele].type !== 'cds.Vector'
+          req.target?.actives.elements[ele].type !== 'cds.LargeBinary' &&
+          req.target?.actives.elements[ele].type !== 'cds.Vector'
       );
 
       const recommendationsIdx = req.query.SELECT.columns.findIndex(
-        (col) => col.ref && col.ref[0] === req.target['@UI.Recommendations']['=']
+        (col) => col.ref && col.ref[0] === req.target?.['@UI.Recommendations']['=']
       );
       if (recommendationsIdx >= 0) {
         req.query.SELECT.columns.splice(recommendationsIdx, 1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/ai",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CAP cds-plugin for AI capabilities",
   "repository": "cap-js/ai",
   "type": "module",

--- a/tests/recommendations.test.js
+++ b/tests/recommendations.test.js
@@ -19,6 +19,15 @@ describe('Fetching recommendations', () => {
     assert.ok(data.value.length >= 0);
   });
 
+  test('active entity returns SAP_Recommendations as null', async () => {
+    const { status, data } = await GET(
+      '/odata/v4/catalog/Books(ID=201,IsActiveEntity=true)?$expand=SAP_Recommendations'
+    );
+    assert.strictEqual(status, 200);
+    assert.strictEqual('SAP_Recommendations' in data, true);
+    assert.strictEqual(data.SAP_Recommendations, null);
+  });
+
   test('In draft mode recommendations are returned', async () => {
     const {
       data: { ID }


### PR DESCRIPTION
# Fix: Empty Recommendations on Active Read

### Bug Fix

🐛 Resolves an issue where active (non-draft) entities were returning empty/missing `SAP_Recommendations` fields instead of explicitly returning `null` when the recommendations field was requested via `$expand`. This ensures the response always contains the `SAP_Recommendations` key when it is part of the query, preventing unexpected behavior in the consuming UI.

### Changes

* `lib/handlers/recommendations.js`:
  - Added a new early-return block to handle READ requests on **active (non-draft)** entities that have the `@UI.Recommendations` annotation. When the recommendations field is included in the query, the handler now explicitly sets it to `null` on each row if not already present, ensuring the field is always present in the response.
  - Added optional chaining (`?.`) to the existing draft-entity condition guards to prevent potential runtime errors when properties are undefined.

* `tests/recommendations.test.js`:
  - Added a new test case `'active entity returns SAP_Recommendations as null'` that verifies a specific active entity (by ID with `IsActiveEntity=true`) returns `SAP_Recommendations` as `null` (i.e., the key is present in the response with a `null` value) when expanded.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.43`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Correlation ID: `1fd196b2-fc08-42dd-8a9d-133366d7a432`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
</details>
