### PR TITLE
feat: implement local inference mode with SAP RPT-1 OSS model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,39 @@ jobs:
       - run: cd tests/bookshop && npm i
       - run: npm run test
 
+  local-tests:
+    runs-on: ubuntu-latest
+    needs: requires-approval
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+        cds-version: [latest]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install sap_rpt_oss
+        run: pip install git+https://github.com/SAP-samples/sap-rpt-1-oss
+      - name: Configure HuggingFace token
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          printf '{"cds":{"rpt":{"hfToken":"%s"}}}\n' "$HF_TOKEN" > tests/bookshop/.cdsrc-private.json
+      - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
+      - run: npm i
+      - run: cd tests/bookshop && npm i
+      - name: Run local RPT e2e tests
+        run: node --test tests/local/local.test.js
+
   integration-tests:
     runs-on: ubuntu-latest
     needs: requires-approval

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ gen/
 package-lock.json
 .env
 .cdsrc-private.json
-resources/.cds-private.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ gen/
 package-lock.json
 .env
 .cdsrc-private.json
-resources/
+resources/.cds-private.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 1.1.0
+
+### Added
+- Local inference mode using the open-source [SAP RPT-1 OSS](https://huggingface.co/SAP/sap-rpt-1-oss) model (`AICore-local`), without requiring an SAP AI Core service binding
+- HuggingFace Inference API mode (`AICore-hf`) as a lightweight alternative that requires only a HuggingFace token
+- Automatic model download on first startup; checkpoint and sentence embedder are cached in `~/.cache/sap-rpt-1-oss/`
+- Configure HuggingFace token via `cds.rpt.hfToken` in `.cdsrc-private.json`
+
 ## Version 1.0.1 - 2026-05-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -173,6 +173,79 @@ cds bind ai-core -2 <your-ai-core-service-instance>
 npm run test:hybrid
 ```
 
+### Local mode (without SAP AI Core)
+
+Instead of connecting to SAP AI Core, you can run the plugin locally using the open-source [SAP RPT-1 OSS](https://huggingface.co/SAP/sap-rpt-1-oss) model. Two backends are supported:
+
+| Kind | How it works | Requires |
+|---|---|---|
+| `AICore-local` | Downloads the model checkpoint (~65 MB) on first startup and runs inference locally via a Python subprocess | Python ≥3.11, `sap_rpt_oss` package |
+| `AICore-hf` | Calls the HuggingFace Inference API — no local Python needed | HuggingFace token |
+
+#### Setup
+
+**1. Accept the model licence**
+
+Visit [https://huggingface.co/SAP/sap-rpt-1-oss](https://huggingface.co/SAP/sap-rpt-1-oss) and click **Agree** while logged in to your HuggingFace account.
+
+**2. Create a HuggingFace token**
+
+Go to [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) and create a fine-grained token with the permission:
+> _Read access to contents of all public gated repos you can access_
+
+**3. Configure the token**
+
+Add a `.cdsrc-private.json` file to your project root (it is gitignored by default):
+
+```json
+{
+  "cds": {
+    "rpt": {
+      "hfToken": "hf_..."
+    }
+  }
+}
+```
+
+**4a. Local inference (`AICore-local`)**
+
+Install the Python package once:
+
+```bash
+pip install git+https://github.com/SAP-samples/sap-rpt-1-oss
+```
+
+Then activate local mode in your `package.json` or `.cdsrc.json`:
+
+```json
+{
+  "cds": {
+    "requires": {
+      "AICore": "AICore-local"
+    }
+  }
+}
+```
+
+On first startup the model checkpoint is downloaded automatically and cached in `~/.cache/SAP/sap-rpt-1-oss/`. Subsequent startups skip the download and load directly from cache.
+
+**4b. HuggingFace Inference API (`AICore-hf`)**
+
+No Python installation needed. Activate with:
+
+```json
+{
+  "cds": {
+    "requires": {
+      "AICore": "AICore-hf"
+    }
+  }
+}
+```
+
+> [!NOTE]
+> The default kind for local development (no CDS profile) is `AICore-local`. Production and hybrid profiles use `AICore-btp`.
+
 ## Support, Feedback, Contributing
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/cap-js/ai/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).

--- a/lib/rpt/infer.py
+++ b/lib/rpt/infer.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+SAP RPT-1 OSS local inference server.
+
+Reads JSON requests from stdin (one per line), runs predictions using the
+locally cached model checkpoint, and writes JSON responses to stdout.
+
+Protocol:
+  stdin  line: {"id": <int>, "data": { ...same payload as predictRowColumns... }}
+  stdout line: {"id": <int>, "result": { "predictions": [...] }}
+              {"id": <int>, "error": "<message>"}
+
+On startup, sends {"id": 0, "result": "ready"} once the model is loaded.
+"""
+import json
+import sys
+import os
+import warnings
+import traceback
+from pathlib import Path
+
+# Silence noisy sap_rpt_oss dtype warnings — we normalise dtypes ourselves below
+warnings.filterwarnings('ignore')
+
+# Redirect any stray prints that sap_rpt_oss writes directly to stdout so they
+# don't corrupt the JSON stdout protocol
+_real_stdout = sys.stdout
+sys.stdout = sys.stderr
+
+# ─── Model loading ────────────────────────────────────────────────────────────
+
+def load_model(model_path: str):
+    """Load the SAP RPT-1 OSS classifier using pre-downloaded cache."""
+    try:
+        from sap_rpt_oss import SAP_RPT_OSS_Classifier
+    except ImportError:
+        _fatal(
+            "sap_rpt_oss package not found.\n"
+            "Install it with: pip install git+https://github.com/SAP-samples/sap-rpt-1-oss"
+        )
+
+    # All model files are pre-downloaded by Node.js into HF_HOME.
+    # Tell huggingface_hub to use only the local cache — no network calls.
+    os.environ.setdefault('HF_HUB_OFFLINE', '1')
+
+    print(f"Loading model (cache: {os.environ.get('HF_HOME', 'default')}) …", file=sys.stderr, flush=True)
+
+    clf = SAP_RPT_OSS_Classifier(
+        bagging=1,
+        max_context_size=512,
+    )
+    return clf
+
+# ─── Inference ────────────────────────────────────────────────────────────────
+
+def _coerce_dtypes(df, data_schema: dict | None):
+    """
+    Coerce DataFrame columns to proper dtypes so sap_rpt_oss doesn't warn.
+    Uses data_schema hints when available, otherwise infers from values.
+    """
+    for col in df.columns:
+        hint = (data_schema or {}).get(col, {}).get('dtype', '')
+        if hint in ('numeric', 'integer', 'float'):
+            df[col] = pd.to_numeric(df[col], errors='coerce')
+        elif hint in ('bool',):
+            df[col] = df[col].astype(bool)
+        elif hint in ('date', 'datetime'):
+            df[col] = pd.to_datetime(df[col], errors='coerce')
+        else:
+            # Try int, then float, fall back to string
+            try:
+                converted = pd.to_numeric(df[col], errors='raise', downcast='integer')
+                df[col] = converted
+            except (ValueError, TypeError):
+                try:
+                    converted = pd.to_numeric(df[col], errors='raise')
+                    df[col] = converted
+                except (ValueError, TypeError):
+                    df[col] = df[col].astype(str).replace('None', pd.NA).replace('nan', pd.NA)
+    return df
+
+
+def predict(clf, data: dict) -> dict:
+    """
+    Run predictions for one request.
+
+    data keys mirror predictRowColumns payload:
+      rows              – list of row dicts
+      prediction_config – { target_columns: [{name, prediction_placeholder, task_type}] }
+      index_column      – name of the ID column
+      data_schema       – optional { col: {dtype} } map
+    """
+    import pandas as pd
+
+    rows = data["rows"]
+    prediction_config = data["prediction_config"]
+    index_column = data["index_column"]
+    data_schema = data.get("data_schema")
+    target_cols = [tc["name"] for tc in prediction_config["target_columns"]]
+    placeholder = prediction_config["target_columns"][0].get("prediction_placeholder", "[PREDICT]")
+
+    df = _coerce_dtypes(pd.DataFrame(rows), data_schema)
+
+    predictions = []
+    for _, row in df.iterrows():
+        row_id = row[index_column]
+        new_pred = {index_column: row_id}
+        needs_prediction = False
+
+        for col in target_cols:
+            if str(row.get(col)) == placeholder or row.get(col) is None:
+                needs_prediction = True
+
+        if not needs_prediction:
+            continue
+
+        # Build training context from rows that are NOT placeholders for this col
+        for col in target_cols:
+            train_rows = [
+                r for r in rows
+                if r.get(col) is not None and str(r.get(col)) != placeholder
+            ]
+            if not train_rows:
+                new_pred[col] = [{"prediction": None}]
+                continue
+
+            X_train = _coerce_dtypes(pd.DataFrame(train_rows).drop(columns=[col], errors="ignore"), data_schema)
+            y_train = pd.DataFrame(train_rows)[col]
+
+            test_row = _coerce_dtypes(df[df[index_column] == row_id].drop(columns=[col], errors="ignore").copy(), data_schema)
+
+            try:
+                clf.fit(X_train, y_train)
+                probas = clf.predict_proba(test_row)
+                classes = clf.classes_
+                # Return top-3 candidates sorted by probability
+                ranked = sorted(
+                    zip(classes, probas[0]),
+                    key=lambda x: x[1],
+                    reverse=True
+                )[:3]
+                new_pred[col] = [{"prediction": str(c), "score": float(p)} for c, p in ranked]
+            except Exception as exc:
+                new_pred[col] = [{"prediction": None, "error": str(exc)}]
+
+        predictions.append(new_pred)
+
+    return {"predictions": predictions}
+
+# ─── I/O loop ─────────────────────────────────────────────────────────────────
+
+def _respond(msg: dict):
+    _real_stdout.write(json.dumps(msg) + "\n")
+    _real_stdout.flush()
+
+def _fatal(msg: str):
+    print(f"FATAL: {msg}", file=sys.stderr, flush=True)
+    sys.exit(1)
+
+def main():
+    model_path = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.environ.get("RPT_MODEL_PATH", "")
+    )
+    if not model_path or not Path(model_path).exists():
+        _fatal(f"Model checkpoint not found at '{model_path}'. Pass path as first argument.")
+
+    clf = load_model(model_path)
+
+    # Signal readiness to the Node.js parent
+    _respond({"id": 0, "result": "ready"})
+    print("Ready — waiting for requests.", flush=True)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(f"Bad JSON: {exc}", file=sys.stderr, flush=True)
+            continue
+
+        req_id = req.get("id")
+        try:
+            result = predict(clf, req["data"])
+            _respond({"id": req_id, "result": result})
+        except Exception:
+            err = traceback.format_exc()
+            print(err, file=sys.stderr, flush=True)
+            _respond({"id": req_id, "error": err.splitlines()[-1]})
+
+if __name__ == "__main__":
+    main()

--- a/lib/rpt/infer.py
+++ b/lib/rpt/infer.py
@@ -17,6 +17,7 @@ import sys
 import os
 import warnings
 import traceback
+import pandas as pd
 from pathlib import Path
 
 # Silence noisy sap_rpt_oss dtype warnings — we normalise dtypes ourselves below
@@ -90,8 +91,6 @@ def predict(clf, data: dict) -> dict:
       index_column      – name of the ID column
       data_schema       – optional { col: {dtype} } map
     """
-    import pandas as pd
-
     rows = data["rows"]
     prediction_config = data["prediction_config"]
     index_column = data["index_column"]
@@ -105,17 +104,19 @@ def predict(clf, data: dict) -> dict:
     for _, row in df.iterrows():
         row_id = row[index_column]
         new_pred = {index_column: row_id}
-        needs_prediction = False
-
-        for col in target_cols:
-            if str(row.get(col)) == placeholder or row.get(col) is None:
-                needs_prediction = True
+        needs_prediction = any(
+            str(row.get(col)) == placeholder or row.get(col) is None
+            for col in target_cols
+        )
 
         if not needs_prediction:
             continue
 
-        # Build training context from rows that are NOT placeholders for this col
+        # Only predict columns that actually need it for this row
         for col in target_cols:
+            if str(row.get(col)) != placeholder and row.get(col) is not None:
+                continue
+
             train_rows = [
                 r for r in rows
                 if r.get(col) is not None and str(r.get(col)) != placeholder
@@ -126,19 +127,13 @@ def predict(clf, data: dict) -> dict:
 
             X_train = _coerce_dtypes(pd.DataFrame(train_rows).drop(columns=[col], errors="ignore"), data_schema)
             y_train = pd.DataFrame(train_rows)[col]
-
             test_row = _coerce_dtypes(df[df[index_column] == row_id].drop(columns=[col], errors="ignore").copy(), data_schema)
 
             try:
                 clf.fit(X_train, y_train)
                 probas = clf.predict_proba(test_row)
                 classes = clf.classes_
-                # Return top-3 candidates sorted by probability
-                ranked = sorted(
-                    zip(classes, probas[0]),
-                    key=lambda x: x[1],
-                    reverse=True
-                )[:3]
+                ranked = sorted(zip(classes, probas[0]), key=lambda x: x[1], reverse=True)[:3]
                 new_pred[col] = [{"prediction": str(c), "score": float(p)} for c, p in ranked]
             except Exception as exc:
                 new_pred[col] = [{"prediction": None, "error": str(exc)}]
@@ -168,7 +163,6 @@ def main():
 
     clf = load_model(model_path)
 
-    # Signal readiness to the Node.js parent
     _respond({"id": 0, "result": "ready"})
     print("Ready — waiting for requests.", flush=True)
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "cds": {
     "requires": {
-      "AICore": "AICore-local",
+      "AICore": "AICore-mocked",
       "[production]": {
         "AICore": "AICore-btp"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@cap-js/cds-test": "^1",
     "@cap-js/cds-types": "^0.16.0",
-    "@cap-js/sqlite": "^9"
+    "@cap-js/sqlite": ">=2"
   },
   "peerDependencies": {
     "@sap/cds": ">=9"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@cap-js/cds-test": "^1",
     "@cap-js/cds-types": "^0.16.0",
-    "@cap-js/sqlite": "*"
+    "@cap-js/sqlite": "^9"
   },
   "peerDependencies": {
     "@sap/cds": ">=9"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "cds": {
     "requires": {
-      "AICore": "AICore-mocked",
+      "AICore": "AICore-local",
       "[production]": {
         "AICore": "AICore-btp"
       },
@@ -49,6 +49,19 @@
           "resourceGroup": "default",
           "vcap": {
             "label": "aicore"
+          }
+        },
+        "AICore-local": {
+          "model": "@cap-js/ai/srv/LocalRPTService",
+          "local": true,
+          "credentials": {
+            "token": ""
+          }
+        },
+        "AICore-hf": {
+          "model": "@cap-js/ai/srv/LocalRPTService",
+          "credentials": {
+            "token": ""
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "cds-plugin.js",
   "scripts": {
     "lint": "npx -y eslint@10 .",
-    "test": "node --test tests/*.test.js",
+    "test": "CDS_ENV=test node --test tests/*.test.js",
     "test:hybrid": "cds bind --exec -- node --test tests/*.test.js tests/integration/*.test.js",
     "format": "npx -y prettier@3 . --write && format-cds -f",
     "format:check": "npx -y prettier@3 --check . && format-cds --check"
@@ -40,6 +40,9 @@
       "[hybrid]": {
         "AICore": "AICore-btp"
       },
+      "[test]": {
+        "AICore": "AICore-mocked"
+      },
       "kinds": {
         "AICore-mocked": {
           "model": "@cap-js/ai/srv/MockAICoreService"
@@ -53,16 +56,10 @@
         },
         "AICore-local": {
           "model": "@cap-js/ai/srv/LocalRPTService",
-          "local": true,
-          "credentials": {
-            "token": ""
-          }
+          "local": true
         },
         "AICore-hf": {
-          "model": "@cap-js/ai/srv/LocalRPTService",
-          "credentials": {
-            "token": ""
-          }
+          "model": "@cap-js/ai/srv/LocalRPTService"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/ai",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "CAP cds-plugin for AI capabilities",
   "repository": "cap-js/ai",
   "type": "module",

--- a/srv/LocalRPTService.cds
+++ b/srv/LocalRPTService.cds
@@ -1,0 +1,3 @@
+using {AICore} from './AICoreService';
+
+annotate AICore with @impl: './LocalRPTService.js';

--- a/srv/LocalRPTService.js
+++ b/srv/LocalRPTService.js
@@ -6,7 +6,6 @@ import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 import { pipeline } from 'node:stream/promises';
-import { createHash } from 'node:crypto';
 
 import AICoreService from './AICoreService.js';
 
@@ -138,15 +137,21 @@ async function ensureEmbedder() {
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
   const base = `https://huggingface.co/${EMBEDDER_ID}/resolve/main`;
 
-  let anyDownloaded = false;
-  for (const file of EMBEDDER_FILES) {
-    const dest = join(snapshotDir, file);
-    if (existsSync(dest) && (await stat(dest)).size > 0) continue;
-    if (!anyDownloaded) {
-      LOG.info(`[Local RPT] downloading sentence embedder (${EMBEDDER_ID})`);
-      anyDownloaded = true;
-    }
-    await _downloadFile(`${base}/${file}`, dest, `${EMBEDDER_ID}/${file}`, headers);
+  const missing = await Promise.all(
+    EMBEDDER_FILES.map(async (file) => {
+      const dest = join(snapshotDir, file);
+      if (existsSync(dest) && (await stat(dest)).size > 0) return null;
+      return file;
+    })
+  ).then((files) => files.filter(Boolean));
+
+  if (missing.length) {
+    LOG.info(`[Local RPT] downloading sentence embedder (${EMBEDDER_ID})`);
+    await Promise.all(
+      missing.map((file) =>
+        _downloadFile(`${base}/${file}`, join(snapshotDir, file), `${EMBEDDER_ID}/${file}`, headers)
+      )
+    );
   }
 
   // Write the refs/main pointer that huggingface_hub uses to resolve the snapshot
@@ -156,7 +161,7 @@ async function ensureEmbedder() {
     writeFileSync(refPath, 'main');
   }
 
-  if (anyDownloaded) process.stderr.write('  Embedder ready.\n\n');
+  if (missing.length) process.stderr.write('  Embedder ready.\n\n');
 }
 
 // ─── HuggingFace Inference API mode ──────────────────────────────────────────

--- a/srv/LocalRPTService.js
+++ b/srv/LocalRPTService.js
@@ -1,0 +1,352 @@
+import cds from '@sap/cds';
+import { createWriteStream, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { createHash } from 'node:crypto';
+
+import AICoreService from './AICoreService.js';
+
+const LOG = cds.log('@cap-js/ai');
+
+const MODEL_ID = 'SAP/sap-rpt-1-oss';
+const MODEL_FILE = '2025-11-04_sap-rpt-one-oss.pt';
+const MODEL_URL = `https://huggingface.co/${MODEL_ID}/resolve/main/${MODEL_FILE}`;
+const HF_INFERENCE_URL = `https://api-inference.huggingface.co/models/${MODEL_ID}`;
+const INFER_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '../lib/rpt/infer.py');
+
+// Sentence embedder downloaded by sap_rpt_oss at classifier init time
+const EMBEDDER_ID = 'sentence-transformers/all-MiniLM-L6-v2';
+const EMBEDDER_FILES = [
+  'config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  'special_tokens_map.json',
+  'vocab.txt',
+  'model.safetensors',
+  '1_Pooling/config.json',
+];
+
+// ─── Cache helpers ────────────────────────────────────────────────────────────
+
+function _cacheDir() {
+  return (
+    cds.env.requires?.AICore?.cacheDir ??
+    join(process.env.HOME ?? process.cwd(), '.cache', 'sap-rpt-1-oss')
+  );
+}
+
+function _modelPath() {
+  return join(_cacheDir(), MODEL_FILE);
+}
+
+/** HuggingFace hub cache root — transformers/huggingface_hub look here. */
+function _hfHome() {
+  return join(_cacheDir(), 'hf');
+}
+
+/**
+ * Returns the directory where huggingface_hub caches a given repo, following
+ * the standard layout: <HF_HOME>/hub/models--<org>--<name>/snapshots/<ref>/
+ */
+function _hfRepoCache(repoId, ref = 'main') {
+  const repoDir = 'models--' + repoId.replace('/', '--');
+  return join(_hfHome(), 'hub', repoDir, 'snapshots', ref);
+}
+
+function _hfToken() {
+  return cds.env.rpt?.hfToken ?? '';
+}
+
+// ─── Download helpers ─────────────────────────────────────────────────────────
+
+/** Download a single URL to dest with a live progress bar on stderr. */
+async function _downloadFile(url, dest, label, headers = {}) {
+  mkdirSync(dirname(dest), { recursive: true });
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(
+        `Access denied when downloading ${label} (HTTP ${res.status}).\n\n` +
+        `  SAP/sap-rpt-1-oss is a gated model — you need a HuggingFace account and must\n` +
+        `  accept the model licence at https://huggingface.co/${MODEL_ID}\n\n` +
+        `  Then provide your HF token via .cdsrc-private.json (gitignored):\n` +
+        `        { "cds": { "rpt": { "hfToken": "hf_..." } } }\n\n` +
+        `  Generate a token at https://huggingface.co/settings/tokens\n` +
+        `  Required permission: "Read access to contents of all public gated repos you can access"`
+      );
+    }
+    throw new Error(`Download failed for ${label}: ${res.status} ${res.statusText}`);
+  }
+
+  const total = parseInt(res.headers.get('content-length') ?? '0', 10);
+  let downloaded = 0;
+  const startTime = Date.now();
+  const BAR_WIDTH = 30;
+
+  function _drawBar() {
+    const pct = total > 0 ? downloaded / total : 0;
+    const filled = Math.round(BAR_WIDTH * pct);
+    const bar = '█'.repeat(filled) + '░'.repeat(BAR_WIDTH - filled);
+    const mb = (n) => (n / 1048576).toFixed(1) + ' MB';
+    const elapsed = (Date.now() - startTime) / 1000;
+    const speed = elapsed > 0 ? downloaded / elapsed : 0;
+    const eta = total > 0 && speed > 0 ? Math.ceil((total - downloaded) / speed) + 's' : '…';
+    const pctStr = total > 0 ? (pct * 100).toFixed(1).padStart(5) + '%' : '  …  ';
+    process.stderr.write(
+      `\r  ${bar}  ${pctStr}  ${mb(downloaded)}${total > 0 ? ' / ' + mb(total) : ''}  ${speed > 0 ? mb(speed) + '/s' : ''}  ETA ${eta}   `
+    );
+  }
+
+  const { Transform } = await import('node:stream');
+  const tracker = new Transform({
+    transform(chunk, _enc, cb) { downloaded += chunk.length; _drawBar(); cb(null, chunk); }
+  });
+
+  process.stderr.write(`\n  Downloading ${label}\n`);
+  _drawBar();
+  await pipeline(res.body, tracker, createWriteStream(dest));
+  process.stderr.write('\n');
+}
+
+/** Ensure the RPT-1 checkpoint is on disk. */
+async function ensureModel() {
+  const dest = _modelPath();
+  if (existsSync(dest) && (await stat(dest)).size > 0) return dest;
+  LOG.info(`[Local RPT] downloading model checkpoint from ${MODEL_URL}`);
+  const token = _hfToken();
+  await _downloadFile(MODEL_URL, dest, `${MODEL_FILE} (${MODEL_ID})`,
+    token ? { Authorization: `Bearer ${token}` } : {});
+  process.stderr.write('  Download complete.\n\n');
+  return dest;
+}
+
+/**
+ * Ensure the sentence embedder is in the HF hub cache layout so
+ * huggingface_hub finds it without hitting the network.
+ *
+ * Layout: <HF_HOME>/hub/models--sentence-transformers--all-MiniLM-L6-v2/
+ *           snapshots/main/<file>
+ */
+async function ensureEmbedder() {
+  const snapshotDir = _hfRepoCache(EMBEDDER_ID);
+  const token = _hfToken();
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const base = `https://huggingface.co/${EMBEDDER_ID}/resolve/main`;
+
+  let anyDownloaded = false;
+  for (const file of EMBEDDER_FILES) {
+    const dest = join(snapshotDir, file);
+    if (existsSync(dest) && (await stat(dest)).size > 0) continue;
+    if (!anyDownloaded) {
+      LOG.info(`[Local RPT] downloading sentence embedder (${EMBEDDER_ID})`);
+      anyDownloaded = true;
+    }
+    await _downloadFile(`${base}/${file}`, dest, `${EMBEDDER_ID}/${file}`, headers);
+  }
+
+  // Write the refs/main pointer that huggingface_hub uses to resolve the snapshot
+  const refPath = join(_hfHome(), 'hub', 'models--' + EMBEDDER_ID.replace('/', '--'), 'refs', 'main');
+  if (!existsSync(refPath)) {
+    mkdirSync(dirname(refPath), { recursive: true });
+    writeFileSync(refPath, 'main');
+  }
+
+  if (anyDownloaded) process.stderr.write('  Embedder ready.\n\n');
+}
+
+// ─── HuggingFace Inference API mode ──────────────────────────────────────────
+
+export class HFInferenceRPTService extends AICoreService {
+  async _getToken() {
+    const token = _hfToken();
+    if (!token)
+      throw new cds.error(
+        'Missing HuggingFace token. Set cds.requires.AICore.credentials.token or HF_TOKEN.'
+      );
+    return token;
+  }
+
+  async _predictRowColumns(req) {
+    const token = await this._getToken();
+    const { prediction_config, index_column, rows, data_schema } = req.data;
+
+    LOG.debug(`[HF Inference] SAP/sap-rpt-1-oss — ${rows.length} row(s)`);
+
+    const res = await fetch(HF_INFERENCE_URL, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        inputs: {
+          data: rows,
+          target_columns: prediction_config.target_columns,
+          index_column,
+          ...(data_schema && { data_schema })
+        }
+      })
+    });
+
+    if (!res.ok) {
+      const ct = res.headers.get('content-type') ?? '';
+      const detail = ct.includes('json') ? JSON.stringify(await res.json()) : await res.text();
+      LOG.error(`[HF Inference] ${res.status}: ${detail}`);
+      return {};
+    }
+
+    const result = await res.json();
+    if (result.error) {
+      LOG.error(`[HF Inference] model error: ${result.error}`);
+      return {};
+    }
+    return result?.predictions !== undefined ? result : { predictions: result };
+  }
+}
+
+// ─── Local Python subprocess mode ────────────────────────────────────────────
+
+export class LocalSubprocessRPTService extends AICoreService {
+  /** @type {import('node:child_process').ChildProcess | null} */
+  _proc = null;
+  /** @type {Map<number, { resolve: Function, reject: Function }>} */
+  _pending = new Map();
+  _nextId = 1;
+  /** Promise that resolves once the subprocess is ready (set in _boot). */
+  _ready = null;
+
+  init() {
+    // Defer boot until after CDS has finished loading .env and all config,
+    // so HF_TOKEN and other env vars are reliably available.
+    cds.once('served', () => {
+      this._ready = this._boot();
+      this._ready.catch((err) => {
+        if (!err.message.includes('sap_rpt_oss not installed'))
+          LOG.error('[Local RPT] startup failed:', err);
+      });
+    });
+    return super.init();
+  }
+
+  async _boot() {
+    // 1. Download model checkpoint + sentence embedder if needed
+    const modelPath = await ensureModel();
+    await ensureEmbedder();
+
+    // 2. Spawn Python inference server
+    const python = cds.env.requires?.AICore?.python ?? 'python3';
+    LOG.info('[Local RPT] starting Python inference process…');
+
+    const token = _hfToken();
+    this._proc = spawn(python, [INFER_SCRIPT, modelPath], {
+      env: {
+        ...process.env,
+        HF_TOKEN: token,
+        HUGGING_FACE_HUB_TOKEN: token,   // legacy env var checked by some HF libs
+        HF_HOME: _hfHome(),              // point Python at our pre-downloaded cache
+        RPT_MODEL_PATH: modelPath
+      },
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    // Stderr from Python — buffer lines so we can detect known errors
+    this._proc.stderr.setEncoding('utf8');
+    const stderrLines = [];
+    this._proc.stderr.on('data', (chunk) => {
+      for (const line of chunk.split('\n').filter(Boolean)) {
+        stderrLines.push(line);
+        LOG.info(`[Local RPT py] ${line}`);
+      }
+    });
+
+    // Each stdout line is a JSON response to a pending request
+    const rl = createInterface({ input: this._proc.stdout });
+    rl.on('line', (line) => {
+      let msg;
+      try { msg = JSON.parse(line); }
+      catch { LOG.warn(`[Local RPT] unexpected stdout: ${line}`); return; }
+      const h = this._pending.get(msg.id);
+      if (!h) return;
+      this._pending.delete(msg.id);
+      msg.error ? h.reject(new Error(msg.error)) : h.resolve(msg.result);
+    });
+
+    this._proc.on('exit', (code) => {
+      const missingPackage = stderrLines.some((l) => l.includes('sap_rpt_oss package not found'));
+      if (missingPackage) {
+        const border = '─'.repeat(60);
+        process.stderr.write(
+          `\n  ┌${border}┐\n` +
+          `  │  sap_rpt_oss Python package is not installed.            │\n` +
+          `  │                                                          │\n` +
+          `  │  Install it once with:                                   │\n` +
+          `  │    pip install git+https://github.com/SAP-samples/       │\n` +
+          `  │                sap-rpt-1-oss                             │\n` +
+          `  │                                                          │\n` +
+          `  │  Requires: Python ≥3.11, torch, transformers             │\n` +
+          `  └${border}┘\n\n`
+        );
+      }
+      if (this._pending.size > 0) {
+        const err = missingPackage
+          ? new Error('sap_rpt_oss not installed — run: pip install git+https://github.com/SAP-samples/sap-rpt-1-oss')
+          : new Error(`Python inference process exited (code ${code})`);
+        for (const [, h] of this._pending) h.reject(err);
+        this._pending.clear();
+      }
+      this._proc = null;
+      this._ready = null;
+    });
+
+    // Python sends {"id":0,"result":"ready"} once the model is loaded
+    await new Promise((resolve, reject) => this._pending.set(0, { resolve, reject }));
+    LOG.info('[Local RPT] model ready');
+  }
+
+  async _predictRowColumns(req) {
+    if (!this._ready) this._ready = this._boot();
+    await this._ready;
+
+    const id = this._nextId++;
+    LOG.debug(`[Local RPT] request #${id} — ${req.data.rows?.length ?? '?'} row(s)`);
+
+    return new Promise((resolve, reject) => {
+      this._pending.set(id, { resolve, reject });
+      this._proc.stdin.write(JSON.stringify({ id, data: req.data }) + '\n');
+    });
+  }
+}
+
+// ─── Default export ───────────────────────────────────────────────────────────
+
+/**
+ * LocalRPTService — used by both `AICore-local` and `AICore-hf` kinds.
+ *
+ * Set `cds.requires.AICore.local: true` to run the model entirely on this
+ * machine (requires Python ≥3.11 + `sap_rpt_oss` installed).
+ * Omit `local` (or set it to false) to call the HuggingFace Inference API.
+ *
+ * On first use with `local: true` the model checkpoint (~65 MB) is downloaded
+ * from HuggingFace automatically during CDS startup and cached in
+ * `~/.cache/SAP/sap-rpt-1-oss/` (override with `cacheDir`).
+ */
+export default class LocalRPTService extends AICoreService {
+  init() {
+    const cfg = cds.env.requires?.AICore ?? {};
+    if (cfg.local === true) {
+      const backend = new LocalSubprocessRPTService();
+      backend.init(); // registers cds.once('served') boot
+      this._predictRowColumns = backend._predictRowColumns.bind(backend);
+      this._getToken = () => Promise.resolve(_hfToken());
+      // _ready is set by backend after 'served' fires; forward it lazily
+      Object.defineProperty(this, '_ready', { get: () => backend._ready });
+    } else {
+      const backend = new HFInferenceRPTService();
+      this._predictRowColumns = backend._predictRowColumns.bind(backend);
+      this._getToken = backend._getToken.bind(backend);
+    }
+    return super.init();
+  }
+}

--- a/srv/LocalRPTService.js
+++ b/srv/LocalRPTService.js
@@ -26,7 +26,7 @@ const EMBEDDER_FILES = [
   'special_tokens_map.json',
   'vocab.txt',
   'model.safetensors',
-  '1_Pooling/config.json',
+  '1_Pooling/config.json'
 ];
 
 // ─── Cache helpers ────────────────────────────────────────────────────────────
@@ -71,12 +71,12 @@ async function _downloadFile(url, dest, label, headers = {}) {
     if (res.status === 401 || res.status === 403) {
       throw new Error(
         `Access denied when downloading ${label} (HTTP ${res.status}).\n\n` +
-        `  SAP/sap-rpt-1-oss is a gated model — you need a HuggingFace account and must\n` +
-        `  accept the model licence at https://huggingface.co/${MODEL_ID}\n\n` +
-        `  Then provide your HF token via .cdsrc-private.json (gitignored):\n` +
-        `        { "cds": { "rpt": { "hfToken": "hf_..." } } }\n\n` +
-        `  Generate a token at https://huggingface.co/settings/tokens\n` +
-        `  Required permission: "Read access to contents of all public gated repos you can access"`
+          `  SAP/sap-rpt-1-oss is a gated model — you need a HuggingFace account and must\n` +
+          `  accept the model licence at https://huggingface.co/${MODEL_ID}\n\n` +
+          `  Then provide your HF token via .cdsrc-private.json (gitignored):\n` +
+          `        { "cds": { "rpt": { "hfToken": "hf_..." } } }\n\n` +
+          `  Generate a token at https://huggingface.co/settings/tokens\n` +
+          `  Required permission: "Read access to contents of all public gated repos you can access"`
       );
     }
     throw new Error(`Download failed for ${label}: ${res.status} ${res.statusText}`);
@@ -103,7 +103,11 @@ async function _downloadFile(url, dest, label, headers = {}) {
 
   const { Transform } = await import('node:stream');
   const tracker = new Transform({
-    transform(chunk, _enc, cb) { downloaded += chunk.length; _drawBar(); cb(null, chunk); }
+    transform(chunk, _enc, cb) {
+      downloaded += chunk.length;
+      _drawBar();
+      cb(null, chunk);
+    }
   });
 
   process.stderr.write(`\n  Downloading ${label}\n`);
@@ -112,14 +116,20 @@ async function _downloadFile(url, dest, label, headers = {}) {
   process.stderr.write('\n');
 }
 
+const MODEL_MIN_SIZE = 50 * 1024 * 1024; // 50 MB — guards against partial downloads
+
 /** Ensure the RPT-1 checkpoint is on disk. */
 async function ensureModel() {
   const dest = _modelPath();
-  if (existsSync(dest) && (await stat(dest)).size > 0) return dest;
+  if (existsSync(dest) && (await stat(dest)).size >= MODEL_MIN_SIZE) return dest;
   LOG.info(`[Local RPT] downloading model checkpoint from ${MODEL_URL}`);
   const token = _hfToken();
-  await _downloadFile(MODEL_URL, dest, `${MODEL_FILE} (${MODEL_ID})`,
-    token ? { Authorization: `Bearer ${token}` } : {});
+  await _downloadFile(
+    MODEL_URL,
+    dest,
+    `${MODEL_FILE} (${MODEL_ID})`,
+    token ? { Authorization: `Bearer ${token}` } : {}
+  );
   process.stderr.write('  Download complete.\n\n');
   return dest;
 }
@@ -155,7 +165,13 @@ async function ensureEmbedder() {
   }
 
   // Write the refs/main pointer that huggingface_hub uses to resolve the snapshot
-  const refPath = join(_hfHome(), 'hub', 'models--' + EMBEDDER_ID.replace('/', '--'), 'refs', 'main');
+  const refPath = join(
+    _hfHome(),
+    'hub',
+    'models--' + EMBEDDER_ID.replace('/', '--'),
+    'refs',
+    'main'
+  );
   if (!existsSync(refPath)) {
     mkdirSync(dirname(refPath), { recursive: true });
     writeFileSync(refPath, 'main');
@@ -171,7 +187,7 @@ export class HFInferenceRPTService extends AICoreService {
     const token = _hfToken();
     if (!token)
       throw new cds.error(
-        'Missing HuggingFace token. Set cds.requires.AICore.credentials.token or HF_TOKEN.'
+        'Missing HuggingFace token. Configure cds.rpt.hfToken in .cdsrc-private.json.'
       );
     return token;
   }
@@ -249,8 +265,8 @@ export class LocalSubprocessRPTService extends AICoreService {
       env: {
         ...process.env,
         HF_TOKEN: token,
-        HUGGING_FACE_HUB_TOKEN: token,   // legacy env var checked by some HF libs
-        HF_HOME: _hfHome(),              // point Python at our pre-downloaded cache
+        HUGGING_FACE_HUB_TOKEN: token, // legacy env var checked by some HF libs
+        HF_HOME: _hfHome(), // point Python at our pre-downloaded cache
         RPT_MODEL_PATH: modelPath
       },
       stdio: ['pipe', 'pipe', 'pipe']
@@ -270,8 +286,12 @@ export class LocalSubprocessRPTService extends AICoreService {
     const rl = createInterface({ input: this._proc.stdout });
     rl.on('line', (line) => {
       let msg;
-      try { msg = JSON.parse(line); }
-      catch { LOG.warn(`[Local RPT] unexpected stdout: ${line}`); return; }
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        LOG.warn(`[Local RPT] unexpected stdout: ${line}`);
+        return;
+      }
       const h = this._pending.get(msg.id);
       if (!h) return;
       this._pending.delete(msg.id);
@@ -284,19 +304,21 @@ export class LocalSubprocessRPTService extends AICoreService {
         const border = '─'.repeat(60);
         process.stderr.write(
           `\n  ┌${border}┐\n` +
-          `  │  sap_rpt_oss Python package is not installed.            │\n` +
-          `  │                                                          │\n` +
-          `  │  Install it once with:                                   │\n` +
-          `  │    pip install git+https://github.com/SAP-samples/       │\n` +
-          `  │                sap-rpt-1-oss                             │\n` +
-          `  │                                                          │\n` +
-          `  │  Requires: Python ≥3.11, torch, transformers             │\n` +
-          `  └${border}┘\n\n`
+            `  │  sap_rpt_oss Python package is not installed.            │\n` +
+            `  │                                                          │\n` +
+            `  │  Install it once with:                                   │\n` +
+            `  │    pip install git+https://github.com/SAP-samples/       │\n` +
+            `  │                sap-rpt-1-oss                             │\n` +
+            `  │                                                          │\n` +
+            `  │  Requires: Python ≥3.11, torch, transformers             │\n` +
+            `  └${border}┘\n\n`
         );
       }
       if (this._pending.size > 0) {
         const err = missingPackage
-          ? new Error('sap_rpt_oss not installed — run: pip install git+https://github.com/SAP-samples/sap-rpt-1-oss')
+          ? new Error(
+              'sap_rpt_oss not installed — run: pip install git+https://github.com/SAP-samples/sap-rpt-1-oss'
+            )
           : new Error(`Python inference process exited (code ${code})`);
         for (const [, h] of this._pending) h.reject(err);
         this._pending.clear();
@@ -318,6 +340,7 @@ export class LocalSubprocessRPTService extends AICoreService {
     LOG.debug(`[Local RPT] request #${id} — ${req.data.rows?.length ?? '?'} row(s)`);
 
     return new Promise((resolve, reject) => {
+      if (!this._proc) return reject(new Error('Python inference process is not running'));
       this._pending.set(id, { resolve, reject });
       this._proc.stdin.write(JSON.stringify({ id, data: req.data }) + '\n');
     });

--- a/tests/bookshop/app/ai-bookshop/ui5-deploy.yaml
+++ b/tests/bookshop/app/ai-bookshop/ui5-deploy.yaml
@@ -1,21 +1,21 @@
 # yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
 specVersion: '4.0'
 metadata:
-    name: ai-bookshop
+  name: ai-bookshop
 type: application
 resources:
-    configuration:
-        propertiesFileSourceEncoding: UTF-8
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
 builder:
-    resources:
-        excludes:
-            - '/test/**'
-            - '/localService/**'
-    customTasks:
-        - name: ui5-task-zipper
-          afterTask: generateCachebusterInfo
-          configuration:
-              archiveName: ai-bookshop
-              relativePaths: true
-              additionalFiles:
-                  - xs-app.json
+  resources:
+    excludes:
+      - '/test/**'
+      - '/localService/**'
+  customTasks:
+    - name: ui5-task-zipper
+      afterTask: generateCachebusterInfo
+      configuration:
+        archiveName: ai-bookshop
+        relativePaths: true
+        additionalFiles:
+          - xs-app.json

--- a/tests/bookshop/app/ai-bookshop/ui5.yaml
+++ b/tests/bookshop/app/ai-bookshop/ui5.yaml
@@ -8,8 +8,8 @@ resources:
 builder:
   resources:
     excludes:
-      - "/test/**"
-      - "/localService/**"
+      - '/test/**'
+      - '/localService/**'
   customTasks:
     - name: ui5-task-zipper
       afterTask: generateVersionInfo

--- a/tests/bookshop/mta.yaml
+++ b/tests/bookshop/mta.yaml
@@ -1,4 +1,4 @@
-_schema-version: "3.1"
+_schema-version: '3.1'
 ID: intelligent-cap-app
 description: A simple CAP project.
 version: 1.0.0
@@ -94,8 +94,7 @@ modules:
       commands:
         - npm install
         - npm run build:cf
-      supported-platforms:
-        []
+      supported-platforms: []
 resources:
   - name: intelligent-cap-app-db
     type: com.sap.xs.hdi-container

--- a/tests/local/local.test.js
+++ b/tests/local/local.test.js
@@ -1,0 +1,104 @@
+import path from 'path';
+import { describe, test, before } from 'node:test';
+import assert from 'node:assert';
+import cdsTest from '@cap-js/cds-test';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let { GET, POST, PATCH } = cdsTest(path.join(__dirname, './bookshop'));
+
+describe('Local RPT recommendations (AICore-local e2e)', () => {
+  before(async () => {
+    // Wait for the Python subprocess to boot and the model to be ready.
+    // LocalSubprocessRPTService exposes _ready on the AICore service instance.
+    const aiCore = await (await import('@sap/cds')).default.connect.to('AICore');
+    if (aiCore._ready) await aiCore._ready;
+  });
+
+  test('recommendations are returned in draft mode', async () => {
+    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+      ID: Math.round(Math.random() * 10000)
+    });
+    const { status, data } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(status, 200);
+    assert.ok(data.SAP_Recommendations);
+    assert.ok(data.SAP_Recommendations.author_ID.length);
+  });
+
+  test('recommendations contain a default suggestion', async () => {
+    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+      ID: Math.round(Math.random() * 10000)
+    });
+    const { status, data } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(status, 200);
+    for (const field of Object.keys(data.SAP_Recommendations)) {
+      assert.strictEqual(data.SAP_Recommendations[field][0].RecommendedFieldIsSuggestion, true);
+    }
+  });
+
+  test('description populated via @Common.Text', async () => {
+    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+      ID: Math.round(Math.random() * 10000)
+    });
+    const { data } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    const rec = data.SAP_Recommendations['author_ID'][0];
+    assert.ok(rec.RecommendedFieldDescription, 'expected description from @Common.Text');
+  });
+
+  test('@UI.RecommendationState: 0 disables field', async () => {
+    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+      ID: Math.round(Math.random() * 10000)
+    });
+    const { data } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(!!data.SAP_Recommendations['authorWORecommendations_ID'], false);
+  });
+
+  test('dynamic @UI.RecommendationState expression enables/disables field', async () => {
+    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+      ID: Math.round(Math.random() * 10000),
+      genre_ID: 13
+    });
+    const { data: off } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(!!off.SAP_Recommendations['authorWDynamicRecommendations_ID'], false);
+
+    await PATCH(`/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)`, { genre_ID: 10 });
+    const { data: on } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(!!on.SAP_Recommendations['authorWDynamicRecommendations_ID'], true);
+  });
+
+  test('entity with non-ID key returns recommendations', async () => {
+    const { data: { notID } } = await POST('/odata/v4/catalog/BooksWithCustomKey', {
+      notID: Math.round(Math.random() * 10000)
+    });
+    const { status, data } = await GET(
+      `/odata/v4/catalog/BooksWithCustomKey(notID=${notID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(status, 200);
+    assert.ok(data.SAP_Recommendations.currency_code.length);
+  });
+
+  test('entity with composed keys returns recommendations', async () => {
+    const { data: { key1, key2 } } = await POST('/odata/v4/catalog/BooksWithComposedKey', {
+      key1: Math.round(Math.random() * 10000),
+      key2: Math.round(Math.random() * 10000)
+    });
+    const { status, data } = await GET(
+      `/odata/v4/catalog/BooksWithComposedKey(key1=${key1},key2=${key2},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(status, 200);
+    assert.ok(data.SAP_Recommendations.currency_code.length);
+  });
+});

--- a/tests/local/local.test.js
+++ b/tests/local/local.test.js
@@ -17,7 +17,9 @@ describe('Local RPT recommendations (AICore-local e2e)', () => {
   });
 
   test('recommendations are returned in draft mode', async () => {
-    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+    const {
+      data: { ID }
+    } = await POST('/odata/v4/catalog/Books', {
       ID: Math.round(Math.random() * 10000)
     });
     const { status, data } = await GET(
@@ -29,7 +31,9 @@ describe('Local RPT recommendations (AICore-local e2e)', () => {
   });
 
   test('recommendations contain a default suggestion', async () => {
-    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+    const {
+      data: { ID }
+    } = await POST('/odata/v4/catalog/Books', {
       ID: Math.round(Math.random() * 10000)
     });
     const { status, data } = await GET(
@@ -42,7 +46,9 @@ describe('Local RPT recommendations (AICore-local e2e)', () => {
   });
 
   test('description populated via @Common.Text', async () => {
-    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+    const {
+      data: { ID }
+    } = await POST('/odata/v4/catalog/Books', {
       ID: Math.round(Math.random() * 10000)
     });
     const { data } = await GET(
@@ -53,7 +59,9 @@ describe('Local RPT recommendations (AICore-local e2e)', () => {
   });
 
   test('@UI.RecommendationState: 0 disables field', async () => {
-    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+    const {
+      data: { ID }
+    } = await POST('/odata/v4/catalog/Books', {
       ID: Math.round(Math.random() * 10000)
     });
     const { data } = await GET(
@@ -63,7 +71,9 @@ describe('Local RPT recommendations (AICore-local e2e)', () => {
   });
 
   test('dynamic @UI.RecommendationState expression enables/disables field', async () => {
-    const { data: { ID } } = await POST('/odata/v4/catalog/Books', {
+    const {
+      data: { ID }
+    } = await POST('/odata/v4/catalog/Books', {
       ID: Math.round(Math.random() * 10000),
       genre_ID: 13
     });
@@ -80,7 +90,9 @@ describe('Local RPT recommendations (AICore-local e2e)', () => {
   });
 
   test('entity with non-ID key returns recommendations', async () => {
-    const { data: { notID } } = await POST('/odata/v4/catalog/BooksWithCustomKey', {
+    const {
+      data: { notID }
+    } = await POST('/odata/v4/catalog/BooksWithCustomKey', {
       notID: Math.round(Math.random() * 10000)
     });
     const { status, data } = await GET(
@@ -91,7 +103,9 @@ describe('Local RPT recommendations (AICore-local e2e)', () => {
   });
 
   test('entity with composed keys returns recommendations', async () => {
-    const { data: { key1, key2 } } = await POST('/odata/v4/catalog/BooksWithComposedKey', {
+    const {
+      data: { key1, key2 }
+    } = await POST('/odata/v4/catalog/BooksWithComposedKey', {
       key1: Math.round(Math.random() * 10000),
       key2: Math.round(Math.random() * 10000)
     });


### PR DESCRIPTION
# Add Local Inference Mode with SAP RPT-1 OSS Model

### New Feature

✨ Introduces a local inference mode for the CAP AI plugin, allowing developers to run predictions using the open-source [SAP RPT-1 OSS](https://huggingface.co/SAP/sap-rpt-1-oss) model without requiring a full SAP AI Core connection. Two backends are supported: a local Python subprocess (`AICore-local`) and the HuggingFace Inference API (`AICore-hf`).

### Changes

* `srv/LocalRPTService.js`: New service implementation with two backend classes:
  - `LocalSubprocessRPTService` — spawns a Python subprocess (`infer.py`), automatically downloads and caches the model checkpoint (~65 MB) and sentence embedder on first startup, and communicates via a JSON stdin/stdout protocol.
  - `HFInferenceRPTService` — calls the HuggingFace Inference API directly, no local Python required.
  - `LocalRPTService` (default export) — delegates to either backend based on the `local: true` config flag.

* `lib/rpt/infer.py`: New Python inference server script that reads JSON requests from stdin, runs predictions using `SAP_RPT_OSS_Classifier`, and writes JSON responses to stdout. Includes dtype coercion, top-3 candidate ranking, and a readiness signal on startup.

* `srv/LocalRPTService.cds`: New CDS definition wiring the `AICore` service to the `LocalRPTService.js` implementation.

* `package.json`: Added `AICore-local` and `AICore-hf` CDS service kinds. Changed the default (no-profile) kind from `AICore-mocked` to `AICore-local`. Production and hybrid profiles continue to use `AICore-btp`.

* `README.md`: Added a "Local mode (without SAP AI Core)" section documenting both backends, setup steps (licence acceptance, HF token creation, `.cdsrc-private.json` configuration), and installation instructions for the Python package.

* `.gitignore`: Fixed an overly broad `resources/` ignore rule to only ignore `resources/.cds-private.json`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.23.0`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `70c2036e-f7c3-4036-857c-28f2e4a906e8`
- Event Trigger: `pull_request.opened`
</details>
