### PR TITLE
fix: only send readable allowed data to AI Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
 
-## Version 1.1.0 - Upcoming
+## Version 1.1.0 - 2026-07-17
 
 ### Added
 - New `@UI.RecommendationState` opt-in annotation for scalar fields to use Regression prediction from RPT-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
 
-## Version 1.1.0 - 2026-07-17
+## Version 1.1.0 - 2026-07-20
 
 ### Added
 - New `@UI.RecommendationState` opt-in annotation for scalar fields to use Regression prediction from RPT-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Extend `task_type` to `{classification, regression}`
 
 ### Fixed
+- Row-level authorization is now enforced when collecting the recommendations context
 - CDS-to-RPT-1 dtype map now correctly maps `cds.Boolean` to `'string'` and `cds.DateTime`/`cds.Timestamp` to `'string'`, fixing HTTP 422 errors from `/predict`
 - Recurisly enhance composition children of draft-enabled entities so recommendations are displayed for nested entities
 - Fix empty-rows server crash in `_fetchPrediction` when draft entity compositions are empty, now returns an empty result instead of throwing a TypeError

--- a/lib/handlers/recommendations.js
+++ b/lib/handlers/recommendations.js
@@ -88,7 +88,7 @@ export default function registerHandlersForRecommendations(srv) {
       // Parallelize actual request and retrieval of records send to RPT-1
       const [records, resWithAllColumns, res] = await Promise.all([
         // The 2000 limit is based on https://help.sap.com/docs/sap-ai-core/generative-ai/sap-rpt-1?locale=en-US; we use the small model, e.g. 2048 max rows; recommended is 2000, thus 2000
-        SELECT.from(req.target.actives).columns(columns).where(where).limit(2000),
+        srv.run(SELECT.from(req.target.actives).columns(columns).where(where).limit(2000)),
         SELECT.from(req.subject).columns(columns.concat(dynamicRecommendations)),
         next()
       ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/ai",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "CAP cds-plugin for AI capabilities",
   "repository": "cap-js/ai",
   "type": "module",

--- a/tests/bookshop/db/data/sap.capire.bookshop-RestrictedBooks.csv
+++ b/tests/bookshop/db/data/sap.capire.bookshop-RestrictedBooks.csv
@@ -1,0 +1,6 @@
+ID,title,owner,author_ID
+1001,Alice Book One,alice,101
+1002,Alice Book Two,alice,107
+2001,Bob Secret Book,bob,150
+2002,Bob Secret Two,bob,170
+2003,Bob Secret Three,bob,150

--- a/tests/bookshop/db/schema.cds
+++ b/tests/bookshop/db/schema.cds
@@ -67,12 +67,12 @@ entity Books : managed {
 }
 
 entity RestrictedBooks : managed {
-  key ID     : Integer @title: '{i18n>ID}';
+  key ID                : Integer @title: '{i18n>ID}';
 
       @mandatory
-      title  : String(20) @title: '{i18n>Title}';
+      title             : String(20) @title: '{i18n>Title}';
 
-      owner  : String @title: 'Owner';
+      owner             : String @title: 'Owner';
 
       @mandatory author : Association to Authors  @title: '{i18n>AUTHOR}'  @Common.Text: author.name  @Common.TextArrangement: #TextFirst  @Common.ValueList: {
                             CollectionPath: 'Authors',

--- a/tests/bookshop/db/schema.cds
+++ b/tests/bookshop/db/schema.cds
@@ -66,6 +66,24 @@ entity Books : managed {
                                       }  @UI.RecommendationState : (genre.name = 'Fantasy' ? 0 : 1);
 }
 
+entity RestrictedBooks : managed {
+  key ID     : Integer @title: '{i18n>ID}';
+
+      @mandatory
+      title  : String(20) @title: '{i18n>Title}';
+
+      owner  : String @title: 'Owner';
+
+      @mandatory author : Association to Authors  @title: '{i18n>AUTHOR}'  @Common.Text: author.name  @Common.TextArrangement: #TextFirst  @Common.ValueList: {
+                            CollectionPath: 'Authors',
+                            Parameters: [{
+                              $Type: 'Common.ValueListParameterInOut',
+                              LocalDataProperty: author_ID,
+                              ValueListProperty: 'ID',
+                            }, ],
+                          };
+}
+
 entity BookDetails : cuid {
   book   : Association to one Books;
   field1 : String;

--- a/tests/bookshop/srv/cat-service.cds
+++ b/tests/bookshop/srv/cat-service.cds
@@ -19,7 +19,7 @@ service CatalogService {
   @requires: 'authenticated-user'
   @restrict: [{
     grant: '*',
-    to   : 'authenticated-user',
+    to: 'authenticated-user',
     where: 'owner = $user.id'
   }]
   @odata.draft.enabled

--- a/tests/bookshop/srv/cat-service.cds
+++ b/tests/bookshop/srv/cat-service.cds
@@ -16,6 +16,15 @@ service CatalogService {
   @odata.draft.enabled
   entity BooksWithCustomKey   as projection on my.BooksWithCustomKey;
 
+  @requires: 'authenticated-user'
+  @restrict: [{
+    grant: '*',
+    to   : 'authenticated-user',
+    where: 'owner = $user.id'
+  }]
+  @odata.draft.enabled
+  entity RestrictedBooks      as projection on my.RestrictedBooks;
+
   entity Authors              as
     select from my.Authors
     excluding {

--- a/tests/recommendations.test.js
+++ b/tests/recommendations.test.js
@@ -193,3 +193,38 @@ describe('Regression predictions', () => {
     assert.strictEqual(typeof data.SAP_Recommendations.price[0].RecommendedFieldValue, 'number');
   });
 });
+
+describe('Row-level authorization', () => {
+  let capturedContextRows;
+  before(async () => {
+    const aiCore = await cds.connect.to('AICore');
+    aiCore.before('fetchPredictions', (req) => {
+      capturedContextRows = req.data.rows;
+    });
+  });
+
+  test('context sent to AI Core only contains rows the user is authorized to read', async () => {
+    capturedContextRows = undefined;
+
+    const {
+      data: { ID }
+    } = await POST(`/odata/v4/catalog/RestrictedBooks`, {
+      ID: Math.round(Math.random() * 100000),
+      owner: 'alice'
+    });
+    const { status } = await GET(
+      `/odata/v4/catalog/RestrictedBooks(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(status, 200);
+
+    assert.ok(capturedContextRows, 'expected fetchPredictions to be called with context rows');
+
+    const owners = capturedContextRows.map((r) => r.owner).filter((o) => o != null);
+    const leakedRows = capturedContextRows.filter((r) => r.owner && r.owner !== 'alice');
+    assert.deepStrictEqual(
+      leakedRows,
+      [],
+      `context leaked rows not owned by alice: ${JSON.stringify(owners)}`
+    );
+  });
+});


### PR DESCRIPTION
## Fix: Enforce Row-Level Authorization Before Sending Data to AI Core

### Description

This PR fixes a security issue where data sent to AI Core (RPT-1) for generating recommendations was not respecting row-level authorization. Previously, the context query used a raw `SELECT` that bypassed CDS service-level restrictions, potentially leaking records the current user is not authorized to read.

### Changes

**🐛 Bug Fix**

- **`lib/handlers/recommendations.js`**: Changed the context data query from a raw `SELECT.from(req.target.actives)...` to `srv.run(SELECT.from(...))`, ensuring the query is executed through the CDS service layer and row-level authorization restrictions (e.g., `@restrict` with `where` conditions) are properly enforced before data is sent to AI Core.

**🧪 Tests**

- **`tests/recommendations.test.js`**: Added a new `Row-level authorization` test suite that intercepts the `fetchPredictions` call and verifies that only rows owned by the authenticated user (`alice`) are included in the context sent to AI Core.
- **`tests/bookshop/db/schema.cds`**: Added `RestrictedBooks` entity with an `owner` field to support the new test.
- **`tests/bookshop/srv/cat-service.cds`**: Exposed `RestrictedBooks` as a draft-enabled, restricted service entity using `@requires` and `@restrict` annotations with a `where: 'owner = $user.id'` condition.
- **`tests/bookshop/db/data/sap.capire.bookshop-RestrictedBooks.csv`**: Added seed data with rows split between `alice` and `bob` to validate authorization filtering.

**📋 Changelog**

- Updated `CHANGELOG.md` to document the row-level authorization fix under version `1.1.0`.

### Have you...

- [x] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- Correlation ID: `5d88c900-81c2-11f1-8843-f78788f80a85`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: Repository PR Template
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
</details>
