### PR TITLE
chore: adapt ci for cds10

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -73,11 +73,10 @@ runs:
       if: inputs.CDS_VERSION == '9'
       shell: bash
       run: |
-        npm pkg set "overrides.@cap-js/sqlite=^2"
-        npm pkg set "overrides.@cap-js/hana=^2"
-        npm pkg set "overrides.@sap/cds-mtxs=^3"
         npm pkg set "devDependencies.@sap/cds=^9"
+        npm pkg set "devDependencies.@cap-js/sqlite=^2"
         npm pkg set --workspace=tests/bookshop "dependencies.@sap/cds=^9"
+        npm pkg set --workspace=tests/bookshop "devDependencies.@cap-js/sqlite=^2"
 
     - name: Install all dependencies
       shell: bash

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -19,6 +19,9 @@ inputs:
   NODE_VERSION:
     description: "Node.js version to use for tests"
     required: true
+  CDS_VERSION:
+    description: "CDS version to install globally (e.g. 9, latest)"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -57,30 +60,34 @@ runs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
-    - name: Use Node.js ${{ inputs.NODE_VERSION}}
+    - name: Use Node.js ${{ inputs.NODE_VERSION }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.NODE_VERSION }}
 
     - name: Install global CDS
       shell: bash
-      run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
-    - name: Install root dependencies
+      run: npm i -g @sap/cds-dk@${{ inputs.CDS_VERSION }}
+
+    - name: Pin CDS 9 compatible stack
+      if: inputs.CDS_VERSION == '9'
       shell: bash
       run: |
-        npm install @sap/cds@${{ matrix.cds-version }}
-        npm install
-    - name: Install bookshop dependencies
+        npm pkg set "overrides.@cap-js/sqlite=^2"
+        npm pkg set "overrides.@cap-js/hana=^2"
+        npm pkg set "overrides.@sap/cds-mtxs=^3"
+        npm pkg set "devDependencies.@sap/cds=^9"
+        npm pkg set --workspace=tests/bookshop "dependencies.@sap/cds=^9"
+
+    - name: Install all dependencies
       shell: bash
-      run: |
-        cd tests/bookshop && npm install @sap/cds@${{ matrix.cds-version }}
-        npm install
-      
+      run: npm install
+
     - name: Set node env for HANA
       run: echo "NODE_VERSION_HANA=$(echo ${{ inputs.NODE_VERSION }} | tr . _)" >> $GITHUB_ENV
       shell: bash
-    - name: Set node env for CDS
-      run: echo "CDS_VERSION=$(echo ${{ matrix.cds-version }} | tr . _)" >> $GITHUB_ENV
+    - name: Set env for CDS version (safe for service names)
+      run: echo "CDS_VERSION_HANA=$(echo ${{ inputs.CDS_VERSION }} | tr . _)" >> $GITHUB_ENV
       shell: bash
     - name: CDS Versions being used
       run: cds v -i
@@ -89,13 +96,13 @@ runs:
     # Deploy model to HANA
     - name: Create HDI Container
       shell: bash
-      run: cf create-service hana hdi-shared cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION
-    - run: cd tests/bookshop/ && cds deploy --to hana:cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION
+      run: cf create-service hana hdi-shared cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION_HANA
+    - run: cd tests/bookshop/ && cds deploy --to hana:cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION_HANA
       shell: bash
 
     # Bind against BTP services
     - name: Bind HANA
-      run: cds bind db -2 cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION -o package.json
+      run: cds bind db -2 cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION_HANA -o package.json
       shell: bash
     - name: Bind AI Core
       run: cds bind ai-core -2 cap-js-ai-core -o package.json
@@ -114,7 +121,7 @@ runs:
     # Cleanup BTP services
     - name: Delete HDI Container Key
       if: ${{ always() }}
-      run: cf delete-service-key cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION-key -f
+      run: cf delete-service-key cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION_HANA cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION_HANA-key -f
       shell: bash
 
     # Note: The initial delete attempt often fails due to an "ongoing operation on service binding" error.
@@ -123,7 +130,7 @@ runs:
       shell: bash
       run: |
         for i in {1..3}; do
-          cf delete-service cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION -f && break
+          cf delete-service cap-js-ai-hana-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-$NODE_VERSION_HANA-$CDS_VERSION_HANA -f && break
           echo "HDI container delete failed, retrying ($i/3)..."
           sleep 10
           if [ "$i" -eq 3 ]; then

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -73,10 +73,11 @@ runs:
       if: inputs.CDS_VERSION == '9'
       shell: bash
       run: |
+        npm pkg set "overrides.@cap-js/sqlite=^2"
+        npm pkg set "overrides.@cap-js/hana=^2"
+        npm pkg set "overrides.@sap/cds-mtxs=^3"
         npm pkg set "devDependencies.@sap/cds=^9"
-        npm pkg set "devDependencies.@cap-js/sqlite=^2"
         npm pkg set --workspace=tests/bookshop "dependencies.@sap/cds=^9"
-        npm pkg set --workspace=tests/bookshop "devDependencies.@cap-js/sqlite=^2"
 
     - name: Install all dependencies
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [reopened, synchronize, opened]
 
@@ -64,7 +64,7 @@ jobs:
         cds-version: [9, latest]
     steps:
       - name: Integration tests
-        uses: cap-js/ai/.github/actions/integration-tests@main
+        uses: cap-js/ai/.github/actions/integration-tests@cds-10
         with:
           CF_API: ${{ secrets.CF_API }}
           CF_USERNAME: ${{ secrets.CF_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [reopened, synchronize, opened]
 
@@ -65,7 +65,7 @@ jobs:
         cds-version: [9, latest]
     steps:
       - name: Integration tests
-        uses: cap-js/ai/.github/actions/integration-tests@main
+        uses: cap-js/ai/.github/actions/integration-tests@cds-10
         with:
           CF_API: ${{ secrets.CF_API }}
           CF_USERNAME: ${{ secrets.CF_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [reopened, synchronize, opened]
 
@@ -64,7 +64,7 @@ jobs:
         cds-version: [9, latest]
     steps:
       - name: Integration tests
-        uses: cap-js/ai/.github/actions/integration-tests@cds-10
+        uses: cap-js/ai/.github/actions/integration-tests@main
         with:
           CF_API: ${{ secrets.CF_API }}
           CF_USERNAME: ${{ secrets.CF_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,16 @@ jobs:
         run: echo "This job has been approved!"
 
   test:
+    name: Tests with Node.js ${{ matrix.node-version }} (CDS ${{ matrix.cds-version }})
     runs-on: ubuntu-latest
     needs: requires-approval
     if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
+    timeout-minutes: 3
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
-        cds-version: [latest]
+        node-version: [22.x, 24.x]
+        cds-version: [9, latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -38,20 +40,29 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Pin CDS 9 compatible stack
+        if: matrix.cds-version == '9'
+        run: |
+          npm pkg set "overrides.@cap-js/sqlite=^2"
+          npm pkg set "overrides.@cap-js/hana=^2"
+          npm pkg set "overrides.@sap/cds-mtxs=^3"
+          npm pkg set "devDependencies.@sap/cds=^9"
+          npm pkg set --workspace=tests/bookshop "dependencies.@sap/cds=^9"
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
-      - run: cd tests/bookshop && npm i
+      - run: cd tests/bookshop && cds v -i
       - run: npm run test
 
   integration-tests:
+    name: Integration Tests with Node.js ${{ matrix.node-version }} (CDS ${{ matrix.cds-version }})
     runs-on: ubuntu-latest
     needs: requires-approval
     if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
-        cds-version: [latest]
+        node-version: [22.x, 24.x]
+        cds-version: [9, latest]
     steps:
       - name: Integration tests
         uses: cap-js/ai/.github/actions/integration-tests@main
@@ -62,3 +73,4 @@ jobs:
           CF_ORG: ${{ secrets.CF_ORG }}
           CF_SPACE: ${{ secrets.CF_SPACE }}
           NODE_VERSION: ${{ matrix.node-version }}
+          CDS_VERSION: ${{ matrix.cds-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,10 @@ jobs:
       - name: Pin CDS 9 compatible stack
         if: matrix.cds-version == '9'
         run: |
-          npm pkg set "overrides.@cap-js/sqlite=^2"
-          npm pkg set "overrides.@cap-js/hana=^2"
-          npm pkg set "overrides.@sap/cds-mtxs=^3"
           npm pkg set "devDependencies.@sap/cds=^9"
+          npm pkg set "devDependencies.@cap-js/sqlite=^2"
           npm pkg set --workspace=tests/bookshop "dependencies.@sap/cds=^9"
+          npm pkg set --workspace=tests/bookshop "devDependencies.@cap-js/sqlite=^2"
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
       - run: cd tests/bookshop && cds v -i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,11 @@ jobs:
       - name: Pin CDS 9 compatible stack
         if: matrix.cds-version == '9'
         run: |
+          npm pkg set "overrides.@cap-js/sqlite=^2"
+          npm pkg set "overrides.@cap-js/hana=^2"
+          npm pkg set "overrides.@sap/cds-mtxs=^3"
           npm pkg set "devDependencies.@sap/cds=^9"
-          npm pkg set "devDependencies.@cap-js/sqlite=^2"
           npm pkg set --workspace=tests/bookshop "dependencies.@sap/cds=^9"
-          npm pkg set --workspace=tests/bookshop "devDependencies.@cap-js/sqlite=^2"
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
       - run: npm i
       - run: cd tests/bookshop && cds v -i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [reopened, synchronize, opened]
 
@@ -65,7 +65,7 @@ jobs:
         cds-version: [9, latest]
     steps:
       - name: Integration tests
-        uses: cap-js/ai/.github/actions/integration-tests@cds-10
+        uses: cap-js/ai/.github/actions/integration-tests@main
         with:
           CF_API: ${{ secrets.CF_API }}
           CF_USERNAME: ${{ secrets.CF_USERNAME }}

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   ],
   "devDependencies": {
     "@cap-js/cds-test": "^1",
-    "@cap-js/cds-types": "^0.16.0",
-    "@cap-js/sqlite": "*"
+    "@cap-js/cds-types": "^0.16.0"
   },
   "peerDependencies": {
     "@sap/cds": ">=9"

--- a/srv/ai-core/deployments.js
+++ b/srv/ai-core/deployments.js
@@ -185,8 +185,10 @@ export async function rpt1ForResourceGroup(req) {
   const deploymentsList = await this.run(
     SELECT.from(deployments).where({ 'resourceGroup.resourceGroupId': resourceGroupId })
   );
-  let deployment = deploymentsList?.find((r) => r.configurationName.match(/rpt-1/));
-  if (!deployment || (deployment.status !== 'RUNNING' && deployment.status !== 'PENDING')) {
+  const rpt1s = (deploymentsList ?? []).filter((r) => r.configurationName?.match(/rpt-1/));
+  let deployment =
+    rpt1s.find((r) => r.status === 'RUNNING') ?? rpt1s.find((r) => r.status === 'PENDING');
+  if (!deployment) {
     // Create RPT-1 deployment on demand if the resource group is missing it
     const configurationsList = await this.run(
       SELECT.from(configurations)
@@ -229,8 +231,10 @@ export async function rpt1ForResourceGroup(req) {
       }
     }
   }
-  this.resourceRPTMappings.set(resourceGroupId, deployment.id);
-  return deployment.id;
+  if (deployment?.status === 'RUNNING') {
+    this.resourceRPTMappings.set(resourceGroupId, deployment.id);
+  }
+  return deployment?.id;
 }
 
 export async function orchestrationForResourceGroup(req) {

--- a/tests/bookshop/mtx/sidecar/package.json
+++ b/tests/bookshop/mtx/sidecar/package.json
@@ -2,11 +2,11 @@
   "name": "bookshop-mtx",
   "dependencies": {
     "@cap-js/ai": "file:../../../../",
-    "@sap/cds": "^9",
-    "@sap/cds-mtxs": "^3"
+    "@sap/cds": ">=9",
+    "@sap/cds-mtxs": ">=3"
   },
   "devDependencies": {
-    "@cap-js/sqlite": "^2"
+    "@cap-js/sqlite": ">=2"
   },
   "engines": {
     "node": ">=20"

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -14,7 +14,7 @@
     "@sap-cloud-sdk/connectivity": "^4",
     "@sap-cloud-sdk/http-client": "^4",
     "@sap-cloud-sdk/resilience": "^4.3.1",
-    "@sap/cds": "^9",
+    "@sap/cds": ">=9",
     "@sap/cds-common-content": "^3.1.0",
     "@sap/cds-mtxs": "^3",
     "@sap/xssec": "^4",

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "dependencies": {
     "@cap-js/ai": "file:../../",
-    "@cap-js/hana": "^2",
+    "@cap-js/hana": ">=2",
     "@sap-ai-sdk/orchestration": "^2.5.0",
     "@sap-ai-sdk/prompt-registry": "^2.5.0",
     "@sap-cloud-sdk/connectivity": "^4",
@@ -16,13 +16,13 @@
     "@sap-cloud-sdk/resilience": "^4.3.1",
     "@sap/cds": ">=9",
     "@sap/cds-common-content": "^3.1.0",
-    "@sap/cds-mtxs": "^3",
+    "@sap/cds-mtxs": ">=3",
     "@sap/xssec": "^4",
     "express": "^5"
   },
   "devDependencies": {
     "@cap-js/cds-types": "^0.16.0",
-    "@cap-js/sqlite": "*"
+    "@cap-js/sqlite": ">=2"
   },
   "engines": {
     "node": "^22.11.0"

--- a/tests/integration/aicore.test.js
+++ b/tests/integration/aicore.test.js
@@ -241,6 +241,32 @@ describe('AICore Service - cds.ql integration', { concurrency: false }, () => {
       assert.ok(created?.id, 'Should create a deployment');
       const deploymentId = created.id;
 
+      t.after(async () => {
+        try {
+          await withTenant('t0', () =>
+            aiCore.send({
+              event: 'stop',
+              entity: 'AICore.deployments',
+              params: [{ id: deploymentId }]
+            })
+          );
+        } catch {
+          /* stop() may fail on UNKNOWN status — ignore */
+        }
+        try {
+          await withTenant('t0', () =>
+            aiCore.run(
+              DELETE.from('AICore.deployments').where({
+                id: deploymentId,
+                'resourceGroup.resourceGroupId': defaultResourceGroupId
+              })
+            )
+          );
+        } catch {
+          /* DELETE may 404 if the test-body DELETE already succeeded — ignore */
+        }
+      });
+
       // Verify it appears in the list
       const afterCreate = await withTenant('t0', () =>
         aiCore.run(

--- a/tests/integration/cleanup-resource-groups.cjs
+++ b/tests/integration/cleanup-resource-groups.cjs
@@ -3,7 +3,7 @@ const cds = require('@sap/cds');
 async function main() {
   const aiCore = await cds.connect.to('AICore');
   const groups = await aiCore.run(SELECT.from('AICore.resourceGroups'));
-  let deleted = 0;
+  let deletedGroups = 0;
   for (const g of groups) {
     const tenantLabel = g.labels?.find((l) => l.key === 'ext.ai.sap.com/CDS_TENANT_ID');
     if (!tenantLabel) continue;
@@ -13,11 +13,36 @@ async function main() {
       await aiCore.run(
         DELETE.from('AICore.resourceGroups').where({ resourceGroupId: g.resourceGroupId })
       );
-      deleted++;
+      deletedGroups++;
     } catch {
       /* best-effort */
     }
   }
-  console.log('Cleaned up ' + deleted + ' test resource groups');
+  console.log('Cleaned up ' + deletedGroups + ' test resource groups');
+
+  const STALE_STATUS = new Set(['UNKNOWN', 'DEAD', 'STOPPED']);
+  let deletedDeployments = 0;
+  try {
+    const deployments = await aiCore.run(
+      SELECT.from('AICore.deployments').where({ 'resourceGroup.resourceGroupId': 'default' })
+    );
+    for (const d of deployments ?? []) {
+      if (!STALE_STATUS.has(d.status)) continue;
+      try {
+        await aiCore.run(
+          DELETE.from('AICore.deployments').where({
+            id: d.id,
+            'resourceGroup.resourceGroupId': 'default'
+          })
+        );
+        deletedDeployments++;
+      } catch {
+        /* best-effort */
+      }
+    }
+  } catch {
+    /* listing may fail if AI Core is unavailable — do not fail the cleanup */
+  }
+  console.log('Cleaned up ' + deletedDeployments + " stale deployments in 'default'");
 }
 main().catch(console.error);

--- a/tests/recommendations.test.js
+++ b/tests/recommendations.test.js
@@ -190,6 +190,11 @@ describe('Regression predictions', () => {
     assert.strictEqual(status, 200);
     assert.ok(data.SAP_Recommendations);
     assert.ok(data.SAP_Recommendations.price.length);
-    assert.strictEqual(typeof data.SAP_Recommendations.price[0].RecommendedFieldValue, 'number');
+    const rec = data.SAP_Recommendations.price[0].RecommendedFieldValue;
+    assert.ok(
+      typeof rec === 'number' || typeof rec === 'string',
+      `RecommendedFieldValue has unexpected type: ${typeof rec}`
+    );
+    assert.ok(Number.isFinite(Number(rec)), `RecommendedFieldValue is not numeric: ${rec}`);
   });
 });


### PR DESCRIPTION
## chore: Adapt CI for CDS 10

This PR updates the CI configuration to support testing against both **CDS 9** and **CDS 10 (latest)** and modernizes the Node.js version matrix.

### Changes

**`.github/workflows/test.yml`**
- Switched trigger from `pull_request_target` to `pull_request`
- Updated Node.js matrix from `[20.x, 22.x]` → `[22.x, 24.x]`
- Expanded CDS version matrix from `[latest]` → `[9, latest]` for both unit and integration tests
- Added a **"Pin CDS 9 compatible stack"** step that sets `npm` overrides for `@cap-js/sqlite`, `@cap-js/hana`, and `@sap/cds-mtxs` to their v2/v3 ranges when testing against CDS 9
- Replaced `cd tests/bookshop && npm i` with `cd tests/bookshop && cds v -i` to log CDS version info
- Added job `name` fields and a `timeout-minutes: 3` to the unit test job
- Updated the integration test action reference from `@main` → `@cds-10`
- Passes `CDS_VERSION` as an input to the integration tests action

**`.github/actions/integration-tests/action.yml`**
- Added a new `CDS_VERSION` input parameter
- Replaced hardcoded `matrix.cds-version` references with `inputs.CDS_VERSION`
- Added **"Pin CDS 9 compatible stack"** step (conditional on `CDS_VERSION == '9'`) that pins compatible dependency versions via `npm pkg set`
- Consolidated dependency installation into a single `npm install` step
- Renamed the CDS env var from `CDS_VERSION` → `CDS_VERSION_HANA` (dot-safe for CF service names) and fixed all references to it in HDI container create/delete/bind commands

### Category
🔧 **Chore**

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: Repository PR Template
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `4cb6dff0-81d0-11f1-8a28-5a2fc615b2ae`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
</details>
