### PR TITLE
chore: bump node in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         cds-version: [latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
### Bump Node.js versions in release workflow

Updates the Node.js version matrix in the release GitHub Actions workflow, replacing Node.js 20.x with 24.x while retaining 22.x.

**Change:** `[20.x, 22.x]` → `[22.x, 24.x]`

This ensures the release pipeline is tested against current and upcoming LTS/active Node.js versions, dropping the now-older 20.x version.

**Category:** Chore

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.0`

- Output Template: Repository PR Template
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `69387290-8416-11f1-8fbe-2e33610bba7f`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
