### PR TITLE
fix: draft-technical 422 on /predict, mocked-service crash; feat: opt-in recommendation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
 
+## Unreleased
+
+### Added
+- New `cds.requires.AICore.recommendations` config flag: `"auto"` (default, current behavior) or `"opt-in"`, where only fields with an explicit truthy `@UI.RecommendationState` are enrolled for recommendations — for controlled, incremental rollouts on large existing models
+
+### Fixed
+- Association/composition elements (e.g. the draft-added `DraftAdministrativeData`) are no longer sent to RPT-1 `/predict`, fixing HTTP 422 errors (and silently empty recommendations) on draft reads whenever other edit drafts of the entity exist
+
 ## Version 1.1.0 - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Association/composition elements (e.g. the draft-added `DraftAdministrativeData`) are no longer sent to RPT-1 `/predict`, fixing HTTP 422 errors (and silently empty recommendations) on draft reads whenever other edit drafts of the entity exist
+- `@UI.RecommendationState` (and other) annotations are no longer copied onto `<Entity>_Recommendations…RecommendedFieldValue`, so dynamic expressions referencing sibling fields (e.g. `(aiWriteEnabled ? 1 : 0)`) no longer fail CDS compile/serve with `anno-missing-rewrite` / "Element has not been found"
 
 ## Version 1.1.0 - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ annotate Books with {
 }
 ```
 
+#### Opt-in mode for a controlled rollout
+
+By default the plugin is **opt-out**: every field with a value help auto-enrolls for recommendations, and each unwanted one has to be silenced with `@UI.RecommendationState : 0`. On a large existing model this can enroll dozens of fields at once and generate unnecessary `/predict` traffic. To invert the default, configure the `AICore` service:
+
+```jsonc
+// package.json or .cdsrc.json → cds.requires
+"AICore": { "recommendations": "opt-in" }
+```
+
+- `"auto"` (default): current behavior — value-helped fields auto-enroll, `@UI.RecommendationState : 0` excludes.
+- `"opt-in"`: a field is enrolled **only** if it carries a truthy `@UI.RecommendationState` (`1` or a dynamic expression); everything else — including value-helped fields — stays out.
+
+```cds
+annotate Books with {
+    genre @UI.RecommendationState : 1; // enrolled
+    // author, currency, … (value help, not annotated) → not enrolled in opt-in mode
+}
+```
+
+`@UI.RecommendationState : 0` wins in both modes, and entities that end up with zero enrolled fields get no `SAP_Recommendations` companion at all.
+
 #### Regression Recommendations on fields without a value help
 
 By default, the plugin only enhances fields that have a value help list since these columns are good prediction targets for classification. However, some fields are good targets but have no value list: free-form numerics like measurement ranges, calibration values, or planning estimates. Annotate these with `@UI.RecommendationState` to opt in:
@@ -96,7 +117,7 @@ On every draft-enabled entity that has at least one value-helped field, it adds 
 On READ requests to a draft entity that expand `SAP_Recommendations`. Reads against the active entity return nothing in that field. Reads during `draftActivate` are skipped.
 
 **What data is sent to RPT-1 as context?**
-Up to 2000 rows from the **active** version of the same entity, restricted to rows where every recommendable field is non-null. The columns `createdAt`, `createdBy`, `modifiedAt`, `modifiedBy` plus any `cds.LargeBinary` / `cds.Vector` elements are stripped. The active row corresponding to the draft (if any) is removed and replaced by the draft row carrying `[PREDICT]` placeholders in the columns to predict. There is no sampling or `ORDER BY` — for tables larger than 2000 rows, which rows make the cut is determined by the database.
+Up to 2000 rows from the **active** version of the same entity, restricted to rows where every recommendable field is non-null. The columns `createdAt`, `createdBy`, `modifiedAt`, `modifiedBy` plus any `cds.LargeBinary` / `cds.Vector` elements and all associations/compositions (their flattened foreign keys remain) are stripped. The active row corresponding to the draft (if any) is removed and replaced by the draft row carrying `[PREDICT]` placeholders in the columns to predict. There is no sampling or `ORDER BY` — for tables larger than 2000 rows, which rows make the cut is determined by the database.
 
 > [!IMPORTANT]
 > Everything in the remaining columns is forwarded to AI Core. Annotate sensitive fields with `@UI.RecommendationState : 0` (or a dynamic expression) to keep them out of both the predictions and the context payload.

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -12,6 +12,7 @@ cds.on('served', async (services) => {
     if (name === 'db') continue;
     // eslint-disable-next-line no-await-in-loop
     const srv = await cds.connect.to(name);
+    if (isExternal(srv)) continue; // external services carry no @UI.Recommendations
     registerHandlersForRecommendations(srv);
 
     if (name === 'cds.xt.DeploymentService') {
@@ -19,3 +20,5 @@ cds.on('served', async (services) => {
     }
   }
 });
+
+const isExternal = (srv) => !!(srv.definition?.['@cds.external'] || srv.definition?.is_external);

--- a/lib/csn-enhancements/recommendations.js
+++ b/lib/csn-enhancements/recommendations.js
@@ -43,9 +43,12 @@ function walkCompositions(name, linkedCSN, model) {
 function enhanceEntity(name, model) {
   const entity = model.definitions[name];
   if (entity['@UI.Recommendations']) return; // already enhanced
+  // 'auto' (default) | 'opt-in' — see README
+  const mode = cds.env.requires?.AICore?.recommendations ?? 'auto';
   const vhFields = Object.keys(entity.elements).reduce((vhFields, ele) => {
     const def = entity.elements[ele];
     if (def['@UI.RecommendationState'] === 0) return vhFields;
+    if (mode === 'opt-in' && !def['@UI.RecommendationState']) return vhFields;
     // 1) Auto-detected: property has a value help.
     const hasValueHelp =
       def['@Common.ValueList.CollectionPath'] ||

--- a/lib/csn-enhancements/recommendations.js
+++ b/lib/csn-enhancements/recommendations.js
@@ -36,6 +36,20 @@ function walkCompositions(name, linkedCSN, model) {
 }
 
 /**
+ * Type template for RecommendedFieldValue — keep the scalar type, drop key and
+ * all annotations. Expression annotations like `@UI.RecommendationState: (foo ? 1 : 0)`
+ * reference sibling elements that do not exist on `<Entity>_Recommendations`.
+ */
+function cloneAsRecommendedValueType(def) {
+  const clone = structuredClone(def);
+  delete clone.key;
+  for (const k of Object.keys(clone)) {
+    if (k.startsWith('@')) delete clone[k];
+  }
+  return clone;
+}
+
+/**
  *
  * @param {string} name Name of entity
  * @param {CSN} model
@@ -56,14 +70,12 @@ function enhanceEntity(name, model) {
     if (hasValueHelp) {
       if (def.keys) {
         for (const key of def.keys) {
-          vhFields[ele + '_' + key.ref.join('_')] = structuredClone(
+          vhFields[ele + '_' + key.ref.join('_')] = cloneAsRecommendedValueType(
             model.definitions[def.target].elements[key.ref]
           );
-          delete vhFields[ele + '_' + key.ref.join('_')].key;
         }
       } else if (!def.on) {
-        vhFields[ele] = structuredClone(def);
-        delete vhFields[ele].key;
+        vhFields[ele] = cloneAsRecommendedValueType(def);
       }
       return vhFields;
     }
@@ -73,8 +85,7 @@ function enhanceEntity(name, model) {
     // UX. Skips associations / compositions / unmanaged elements — those
     // are handled by the value-help branch above.
     if (def['@UI.RecommendationState'] && !def.target && !def.on) {
-      vhFields[ele] = structuredClone(def);
-      delete vhFields[ele].key;
+      vhFields[ele] = cloneAsRecommendedValueType(def);
     }
     return vhFields;
   }, {});

--- a/lib/handlers/recommendations.js
+++ b/lib/handlers/recommendations.js
@@ -4,6 +4,8 @@ const LOG = cds.log('@cap-js/ai');
 export default function registerHandlersForRecommendations(srv) {
   srv.prepend(() =>
     srv.on('READ', async (req, next) => {
+      if (!req.target) return next();
+
       if (!req.target?.isDraft && req.target?.['@UI.Recommendations']) {
         const recommendationsStruct = req.target?.['@UI.Recommendations']['='];
         if (req.query.elements?.[recommendationsStruct]) {
@@ -23,8 +25,8 @@ export default function registerHandlersForRecommendations(srv) {
       // Recommendations annotation is missing on draft entity, thus req.target.actives
       if (
         !req.target?.isDraft ||
-        !req.target?.actives['@UI.Recommendations'] ||
-        !req.query?.elements[req.target?.['@UI.Recommendations']['=']] ||
+        !req.target?.actives?.['@UI.Recommendations'] ||
+        !req.query?.elements[req.target?.['@UI.Recommendations']?.['=']] ||
         req._?.event === 'draftActivate'
       ) {
         return next();

--- a/lib/handlers/recommendations.js
+++ b/lib/handlers/recommendations.js
@@ -43,6 +43,8 @@ export default function registerHandlersForRecommendations(srv) {
           ele !== 'modifiedBy' &&
           ele !== 'createdAt' &&
           ele !== 'createdBy' &&
+          // Associations have no RPT-1 dtype and leak non-scalar values into /predict.
+          !req.target?.actives.elements[ele].isAssociation &&
           req.target?.actives.elements[ele].type !== 'cds.LargeBinary' &&
           req.target?.actives.elements[ele].type !== 'cds.Vector'
       );

--- a/lib/handlers/recommendations.js
+++ b/lib/handlers/recommendations.js
@@ -38,15 +38,22 @@ export default function registerHandlersForRecommendations(srv) {
         model.definitions[req.target?.actives.elements[recommendationsStruct].target];
 
       const columns = Object.keys(req.target.actives.elements).filter(
-        (ele) =>
-          ele !== 'modifiedAt' &&
-          ele !== 'modifiedBy' &&
-          ele !== 'createdAt' &&
-          ele !== 'createdBy' &&
-          // Associations have no RPT-1 dtype and leak non-scalar values into /predict.
-          !req.target?.actives.elements[ele].isAssociation &&
-          req.target?.actives.elements[ele].type !== 'cds.LargeBinary' &&
-          req.target?.actives.elements[ele].type !== 'cds.Vector'
+        (ele) => {
+          const element = req.target?.actives.elements[ele];
+          return (
+            ele !== 'modifiedAt' &&
+            ele !== 'modifiedBy' &&
+            ele !== 'createdAt' &&
+            ele !== 'createdBy' &&
+            // Associations have no RPT-1 dtype and leak non-scalar values into /predict.
+            !element.isAssociation &&
+            !element.virtual &&
+            !element['@Core.Computed'] &&
+            element['@AI.Feature'] !== false &&
+            element.type !== 'cds.LargeBinary' &&
+            element.type !== 'cds.Vector'
+          );
+        }
       );
 
       const recommendationsIdx = req.query.SELECT.columns.findIndex(

--- a/srv/AICoreService.js
+++ b/srv/AICoreService.js
@@ -159,7 +159,7 @@ export default class AICore extends cds.ApplicationService {
     if (rowColumnCount > RPT1_MAX_ROW_COLUMNS) {
       LOG.warn(
         `Skipping recommendations for ${entityName}: rows carry ${rowColumnCount} columns, exceeding the RPT-1 limit of ${RPT1_MAX_ROW_COLUMNS}. ` +
-          'Either narrow the entity projection or opt out @cds.api.ignore-style columns that are not useful as features.'
+          'Either narrow the entity projection or opt out non-feature fields via @AI.Feature: false.'
       );
       return {};
     }

--- a/tests/bookshop/db/schema.cds
+++ b/tests/bookshop/db/schema.cds
@@ -41,6 +41,9 @@ entity Books : managed {
       stock                         : Integer @title: '{i18n>Stock}';
       price                         : Decimal(6, 2)  @title: '{i18n>Price}'  @UI.RecommendationState;
       currency                      : Currency  @Common.ValueListWithFixedValues  @title: '{i18n>Currency}';
+      computedUiState               : String @Core.Computed;
+      virtual virtualUiState        : String @Core.Computed;
+      nonPredictiveFeature          : String @AI.Feature: false;
       chapters                      : Composition of many Chapters
                                         on chapters.book = $self;
       image                         : LargeBinary @Core.MediaType: 'image/png';

--- a/tests/recommendations-opt-in.test.js
+++ b/tests/recommendations-opt-in.test.js
@@ -1,0 +1,59 @@
+import path from 'path';
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import cds from '@sap/cds';
+import cdsTest from '@cap-js/cds-test';
+import { fileURLToPath } from 'url';
+// Get __dirname equivalent in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let { GET, POST, axios } = cdsTest(path.join(__dirname, './bookshop'));
+axios.defaults.auth = { username: 'alice' };
+// Set before cds-test boots the server; the CSN enhancement reads it at compile time.
+cds.env.requires.AICore.recommendations = 'opt-in';
+
+describe('Opt-in recommendation mode', () => {
+  test('only fields with explicit truthy @UI.RecommendationState are enrolled', async () => {
+    const recommendationElements =
+      cds.model.definitions['CatalogService.Books_Recommendations'].elements;
+    // price carries a plain truthy @UI.RecommendationState
+    assert.ok(recommendationElements.price);
+    // dynamic expressions count as explicit opt-in
+    assert.ok(recommendationElements.authorWDynamicRecommendations_ID);
+    // value-help fields without the annotation no longer auto-enroll
+    assert.strictEqual('author_ID' in recommendationElements, false);
+    assert.strictEqual('genre_ID' in recommendationElements, false);
+    assert.strictEqual('currency_code' in recommendationElements, false);
+    // @UI.RecommendationState : 0 still excludes
+    assert.strictEqual('authorWORecommendations_ID' in recommendationElements, false);
+  });
+
+  test('entity with no enrolled fields gets no SAP_Recommendations companion', async () => {
+    // BooksWithCustomKey only has value-help fields, none explicitly opted in
+    assert.strictEqual(
+      'SAP_Recommendations' in cds.model.definitions['CatalogService.BooksWithCustomKey'].elements,
+      false
+    );
+    assert.strictEqual(
+      !!cds.model.definitions['CatalogService.BooksWithCustomKey_Recommendations'],
+      false
+    );
+    const { status } = await GET(`/odata/v4/catalog/BooksWithCustomKey`);
+    assert.strictEqual(status, 200);
+  });
+
+  test('draft READ returns predictions only for opted-in fields', async () => {
+    const {
+      data: { ID }
+    } = await POST(`/odata/v4/catalog/Books`, { ID: Math.round(Math.random() * 10000) });
+    const { status, data } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(status, 200);
+    assert.ok(data.SAP_Recommendations);
+    assert.ok(data.SAP_Recommendations.price.length);
+    assert.strictEqual('author_ID' in data.SAP_Recommendations, false);
+    assert.strictEqual('genre_ID' in data.SAP_Recommendations, false);
+  });
+});

--- a/tests/recommendations.test.js
+++ b/tests/recommendations.test.js
@@ -199,6 +199,50 @@ describe('Regression predictions', () => {
   });
 });
 
+describe('Draft-technical association fields', () => {
+  let capturedContextRows;
+  before(async () => {
+    const aiCore = await cds.connect.to('AICore');
+    aiCore.before('fetchPredictions', (req) => {
+      capturedContextRows = req.data.rows;
+    });
+  });
+
+  test('rows sent to AI Core carry no DraftAdministrativeData or other associations', async () => {
+    capturedContextRows = undefined;
+
+    // Put an existing active book into edit-draft so an *active* context row
+    // resolves DraftAdministrativeData to a non-null value
+    await POST(`/odata/v4/catalog/Books(ID=201,IsActiveEntity=true)/CatalogService.draftEdit`, {
+      PreserveChanges: true
+    });
+
+    const {
+      data: { ID }
+    } = await POST(`/odata/v4/catalog/Books`, { ID: Math.round(Math.random() * 10000) });
+    const { status } = await GET(
+      `/odata/v4/catalog/Books(ID=${ID},IsActiveEntity=false)?$expand=SAP_Recommendations`
+    );
+    assert.strictEqual(status, 200);
+
+    assert.ok(capturedContextRows, 'expected fetchPredictions to be called with context rows');
+
+    for (const row of capturedContextRows) {
+      assert.strictEqual(
+        'DraftAdministrativeData' in row,
+        false,
+        `row leaks DraftAdministrativeData: ${JSON.stringify(row)}`
+      );
+      for (const [key, value] of Object.entries(row)) {
+        assert.ok(
+          value === null || typeof value !== 'object',
+          `row carries non-scalar value for "${key}": ${JSON.stringify(row[key])}`
+        );
+      }
+    }
+  });
+});
+
 describe('Row-level authorization', () => {
   let capturedContextRows;
   before(async () => {

--- a/tests/recommendations.test.js
+++ b/tests/recommendations.test.js
@@ -97,6 +97,13 @@ describe('Classification predictions', () => {
       ],
       true
     );
+    // Expression stays on the source field; companion value type must not inherit it
+    // (sibling paths like genre_ID / aiWriteEnabled are not resolvable there).
+    const valueType =
+      cds.model.definitions['CatalogService.Books_Recommendations'].elements[
+        'authorWDynamicRecommendations_ID'
+      ].items.elements.RecommendedFieldValue;
+    assert.strictEqual(valueType['@UI.RecommendationState'], undefined);
 
     const {
       data: { ID }

--- a/tests/recommendations.test.js
+++ b/tests/recommendations.test.js
@@ -215,7 +215,7 @@ describe('Draft-technical association fields', () => {
     });
   });
 
-  test('rows sent to AI Core carry no DraftAdministrativeData or other associations', async () => {
+  test('rows sent to AI Core exclude non-predictive fields', async () => {
     capturedContextRows = undefined;
 
     // Put an existing active book into edit-draft so an *active* context row
@@ -244,6 +244,13 @@ describe('Draft-technical association fields', () => {
         assert.ok(
           value === null || typeof value !== 'object',
           `row carries non-scalar value for "${key}": ${JSON.stringify(row[key])}`
+        );
+      }
+      for (const field of ['computedUiState', 'virtualUiState', 'nonPredictiveFeature']) {
+        assert.strictEqual(
+          field in row,
+          false,
+          `row carries non-predictive field "${field}": ${JSON.stringify(row[field])}`
         );
       }
     }


### PR DESCRIPTION
This PR bundles two fixes and one feature for the recommendations plugin. Each is an independent commit; happy to split into separate PRs if preferred.

---

## 1. fix: exclude association elements from RPT-1 prediction rows ([5e55030](https://github.com/cap-js/ai/commit/5e55030))

The draft branch of the recommendations READ handler builds its column list from all elements of `req.target.actives`, filtering out only audit fields, `cds.LargeBinary` and `cds.Vector`. Association/composition elements pass the filter — including the compiler-added `DraftAdministrativeData` on draft-enabled entities. These have no RPT-1 dtype (`cdsToPythonDtype` returns `undefined`), so they are omitted from `data_schema` but still present in `rows`. Whenever other edit drafts of the entity exist, context rows resolve `DraftAdministrativeData` to a non-scalar value and AI Core rejects the whole payload:

```
422 {"detail":[{"loc":["rows",7,"DraftAdministrativeData","str"],"msg":"Input should be a valid string",...}]}
```

The error is swallowed (empty predictions), so recommendations silently disappear while every draft READ with `$expand=SAP_Recommendations` still pays a full failed round-trip to AI Core — observed as recurring latency on a production-adjacent stage with concurrent drafts.

**Repro:** open an edit draft of an entity with `@UI.Recommendations`, then READ another draft of that entity with `$expand=SAP_Recommendations`.

**Fix:** skip `isAssociation` elements when building the column list. Flattened foreign keys (`author_ID`, …) are separate scalar elements and remain included — they are the actual prediction targets and features. A regression test opens an edit draft (so an active context row carries draft administrative data) and asserts the rows handed to `fetchPredictions` contain no association keys or non-scalar values; it fails on `main` and passes with the fix.

---

## 2. feat: opt-in recommendation mode ([533e7ac](https://github.com/cap-js/ai/commit/533e7ac))

Today the plugin is opt-out: every value-helped field auto-enrolls, and each unwanted one must be silenced with `@UI.RecommendationState : 0`. On large existing models this enrolls dozens of fields at once and generates unnecessary `/predict` traffic. New config flag:

```jsonc
// cds.requires
"AICore": { "recommendations": "opt-in" }
```

- `"auto"` (default): unchanged behavior — absence of the flag is byte-for-byte identical to today.
- `"opt-in"`: a field is enrolled **only** if it carries a truthy `@UI.RecommendationState` (`1` or a dynamic expression); value-helped fields without it stay out.

`@UI.RecommendationState : 0` wins in both modes; entities with zero enrolled fields get no `SAP_Recommendations` companion (existing guard). Tests boot the bookshop in opt-in mode in its own process; README and CHANGELOG updated.

---

## 3. fix: skip mocked services and guard undefined `req.target` ([2b3fc60](https://github.com/cap-js/ai/commit/2b3fc60))

`cds-plugin.js` registered the recommendations READ handler on every served service, including external services running with a mock fallback (`srv.mocked`). A free-form READ on such a service (e.g. `srv.send(new cds.Request({ method, path }))`) has no `req.target`, so the handler crashed with a `TypeError` on `req.target.isDraft`. Mocked services are now skipped at registration, and the handler additionally bails out early when `req.target` is `undefined` (defense in depth).

---

## Verification

- `npm test`: 18/18 (`node --test`, sqlite bookshop + `MockAICoreService`), including the new 422 regression test and 3 opt-in mode tests
- `eslint` and `prettier --check` clean