### PR TITLE
chore: add @cap-js/node-js-runtime to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @cap-js/cdsmunich
-* @cds-js/node-js-runtime
+* @cap-js/node-js-runtime

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @cap-js/cdsmunich
-* @cap-js/node-js-runtime
+* @cap-js/cdsmunich @cap-js/node-js-runtime

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @cap-js/cdsmunich
+* @cds-js/node-js-runtime


### PR DESCRIPTION
### Add `@cap-js/node-js-runtime` to CODEOWNERS

This change updates the `.github/CODEOWNERS` file to add `@cap-js/node-js-runtime` as a code owner alongside the existing `@cap-js/cdsmunich` team.

**Category:** Chore

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.47`

- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `65878b70-a155-11f1-810f-3f3d8d42d9c6`
- File Content Strategy: Full file content
</details>
