### PR TITLE
fix: truncate embeddings to one model window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Supports both 3-parameter `(text, text_type, model_and_version)` and 4-parameter variants with `remote_source`
   - Compatible with `SAP_GXY.20250407` and `SAP_GXY.20240715` model versions
   - Synchronous execution suitable for SQLite user-defined functions
+  - Embeds one model input window; applications split long documents and store one vector per chunk
   - **Note**: Produces 384-dimensional vectors (vs. 768 in SAP HANA) for efficiency in local development scenarios
 
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ SELECT.from('Books').columns`
 `;
 ```
 
+`VECTOR_EMBEDDING` embeds one model input window. Text beyond the tokenizer's input limit is truncated. For long-document retrieval, split documents before persistence and store one vector per chunk instead of combining chunk embeddings in this function.
+
 **Parameters:**
 - `text` - Text to embed (`NULL` remains `NULL`; empty text returns a zero vector)
 - `text_type` - Type of text, e.g., `'DOCUMENT'` (currently informational)
@@ -250,6 +252,7 @@ SELECT.from('Books').columns`
 **Features:**
 - **Initialization**: The ONNX model is loaded when the `ai-sqlite` service starts
 - **Verified cache**: The pinned model revision is cached by default below the user's data directory; set `CDS_AI_MODEL_CACHE` to use a pre-provisioned cache root
+- **Predictable input**: Embeds the first model input window and truncates longer text
 - **Deterministic**: Same input always produces same output
 - **Normalized vectors**: All embeddings are L2-normalized
 - **Semantic similarity**: Embeddings capture text meaning for similarity search

--- a/lib/vector_embedding/embedding.js
+++ b/lib/vector_embedding/embedding.js
@@ -50,10 +50,11 @@ function wordPieceTokenizer(text, tokenizer) {
   const tokens = [clsToken];
   const ids = [clsId];
 
-  for (const preToken of preTokens) {
+  tokenize: for (const preToken of preTokens) {
     const wordPieceTokens = wordPieceTokenize(preToken, vocab, unkToken);
 
     for (const wpToken of wordPieceTokens) {
+      if (ids.length >= maxLength - 1) break tokenize;
       const tokenId = vocab.get(wpToken) ?? unkId;
       tokens.push(wpToken);
       ids.push(tokenId);
@@ -63,88 +64,49 @@ function wordPieceTokenizer(text, tokenizer) {
   tokens.push(sepToken);
   ids.push(sepId);
 
-  if (tokens.length <= maxLength) return [{ tokens, ids }];
-
-  // Keep each chunk within the limit embedded in the pinned tokenizer.
-  const maxContentLength = maxLength - 2;
-  const chunks = [];
-  const contentTokens = tokens.slice(1, -1);
-  const contentIds = ids.slice(1, -1);
-
-  for (let i = 0; i < contentTokens.length; i += maxContentLength) {
-    const chunkTokens = [clsToken, ...contentTokens.slice(i, i + maxContentLength), sepToken];
-    const chunkIds = [clsId, ...contentIds.slice(i, i + maxContentLength), sepId];
-
-    chunks.push({
-      tokens: chunkTokens,
-      ids: chunkIds
-    });
-  }
-
-  return chunks;
+  return { tokens, ids };
 }
 
 /**
- * Process embeddings for multiple chunks and combine them
+ * Process one model input window.
  */
-function processChunkedEmbeddings(chunks, session) {
-  const embeddings = [];
+function processEmbedding({ ids }, session) {
+  const validIds = validateTokenIds(ids);
 
-  for (const chunk of chunks) {
-    const { ids } = chunk;
-    const validIds = validateTokenIds(ids);
+  const inputIds = new BigInt64Array(validIds.map((i) => BigInt(i)));
+  const attentionMask = new BigInt64Array(validIds.length).fill(BigInt(1));
+  const tokenTypeIds = new BigInt64Array(validIds.length).fill(BigInt(0));
 
-    const inputIds = new BigInt64Array(validIds.map((i) => BigInt(i)));
-    const attentionMask = new BigInt64Array(validIds.length).fill(BigInt(1));
-    const tokenTypeIds = new BigInt64Array(validIds.length).fill(BigInt(0));
+  const inputTensor = new Tensor('int64', inputIds, [1, validIds.length]);
+  const attentionTensor = new Tensor('int64', attentionMask, [1, validIds.length]);
+  const tokenTypeTensor = new Tensor('int64', tokenTypeIds, [1, validIds.length]);
 
-    const inputTensor = new Tensor('int64', inputIds, [1, validIds.length]);
-    const attentionTensor = new Tensor('int64', attentionMask, [1, validIds.length]);
-    const tokenTypeTensor = new Tensor('int64', tokenTypeIds, [1, validIds.length]);
+  const feeds = {
+    input_ids: inputTensor,
+    attention_mask: attentionTensor,
+    token_type_ids: tokenTypeTensor
+  };
 
-    const feeds = {
-      input_ids: inputTensor,
-      attention_mask: attentionTensor,
-      token_type_ids: tokenTypeTensor
-    };
+  const results = session.run(feeds);
+  const lastHiddenState = results['last_hidden_state'];
+  if (!lastHiddenState)
+    throw new Error(
+      `ONNX model output 'last_hidden_state' not found. Available outputs: ${Object.keys(results).join(', ')}`
+    );
+  const [, sequenceLength, hiddenSize] = lastHiddenState.dims;
+  const embeddingData = lastHiddenState.data;
 
-    const results = session.run(feeds);
-    const lastHiddenState = results['last_hidden_state'];
-    if (!lastHiddenState)
-      throw new Error(
-        `ONNX model output 'last_hidden_state' not found. Available outputs: ${Object.keys(results).join(', ')}`
-      );
-    const [, sequenceLength, hiddenSize] = lastHiddenState.dims;
-    const embeddingData = lastHiddenState.data;
-
-    // Apply mean pooling across the sequence dimension
-    const pooledEmbedding = new Float32Array(hiddenSize);
-    for (let i = 0; i < hiddenSize; i++) {
-      let sum = 0;
-      for (let j = 0; j < sequenceLength; j++) {
-        sum += embeddingData[j * hiddenSize + i];
-      }
-      pooledEmbedding[i] = sum / sequenceLength;
-    }
-
-    embeddings.push(pooledEmbedding);
-  }
-
-  // If multiple chunks, average the embeddings
-  if (embeddings.length === 1) return embeddings[0];
-
-  const hiddenSize = embeddings[0].length;
-  const avgEmbedding = new Float32Array(hiddenSize);
-
+  // Apply mean pooling across the sequence dimension.
+  const pooledEmbedding = new Float32Array(hiddenSize);
   for (let i = 0; i < hiddenSize; i++) {
     let sum = 0;
-    for (const embedding of embeddings) {
-      sum += embedding[i];
+    for (let j = 0; j < sequenceLength; j++) {
+      sum += embeddingData[j * hiddenSize + i];
     }
-    avgEmbedding[i] = sum / embeddings.length;
+    pooledEmbedding[i] = sum / sequenceLength;
   }
 
-  return avgEmbedding;
+  return pooledEmbedding;
 }
 
 let session = null;
@@ -161,8 +123,8 @@ function embedding(text) {
     throw new Error(
       'Embedding session not initialized. Call createSession() before using embedding().'
     );
-  const chunks = wordPieceTokenizer(text, tokenizer);
-  const vector = normalizeEmbedding(processChunkedEmbeddings(chunks, session));
+  const input = wordPieceTokenizer(text, tokenizer);
+  const vector = normalizeEmbedding(processEmbedding(input, session));
 
   const chunkObj = { content: text };
   return Object.defineProperty(chunkObj, 'embedding', {

--- a/lib/vector_embedding/embedding.js
+++ b/lib/vector_embedding/embedding.js
@@ -54,7 +54,7 @@ function wordPieceTokenizer(text, tokenizer) {
     const wordPieceTokens = wordPieceTokenize(preToken, vocab, unkToken);
 
     for (const wpToken of wordPieceTokens) {
-      if (ids.length >= maxLength - 1) break tokenize;
+      if (ids.length + wordPieceTokens.length > maxLength - 1) break tokenize;
       const tokenId = vocab.get(wpToken) ?? unkId;
       tokens.push(wpToken);
       ids.push(tokenId);

--- a/tests/vector-unit.test.js
+++ b/tests/vector-unit.test.js
@@ -40,20 +40,19 @@ describe('BERT tokenizer', () => {
   };
 
   test('applies BERT accent, punctuation, and Chinese character normalization', () => {
-    const [chunk] = wordPieceTokenizer('Héllo, café中文', tokenizer);
+    const chunk = wordPieceTokenizer('Héllo, café中文', tokenizer);
 
     assert.deepEqual(chunk.tokens, ['[CLS]', 'hello', ',', 'cafe', '中', '文', '[SEP]']);
     assert.deepEqual(chunk.ids, [101, 200, 201, 202, 203, 204, 102]);
   });
 
-  test('uses the tokenizer model limit without an off-by-one', () => {
-    const chunks = wordPieceTokenizer(new Array(130).fill('token').join(' '), tokenizer);
+  test('truncates input to one model window without an off-by-one', () => {
+    const firstWindow = wordPieceTokenizer(new Array(126).fill('token').join(' '), tokenizer);
+    const longInput = wordPieceTokenizer(new Array(130).fill('token').join(' '), tokenizer);
 
-    assert.deepEqual(
-      chunks.map(({ ids }) => ids.length),
-      [128, 6]
-    );
-    assert.ok(chunks.every(({ ids }) => ids.length <= tokenizer.maxLength));
+    assert.equal(longInput.ids.length, tokenizer.maxLength);
+    assert.deepEqual(longInput.ids, [101, ...new Array(126).fill(205), 102]);
+    assert.deepEqual(longInput, firstWindow);
   });
 });
 

--- a/tests/vector.test.js
+++ b/tests/vector.test.js
@@ -27,6 +27,18 @@ describe('Vector embedding function (standalone)', () => {
       assert.strictEqual(e1, e2, 'Same input should produce identical embeddings');
     });
 
+    test('ignores text beyond the first model input window', () => {
+      const firstWindow = new Array(126).fill('token').join(' ');
+      const truncated = vector_embedding(firstWindow, 'DOCUMENT', 'SAP_GXY.20250407');
+      const withAdditionalText = vector_embedding(
+        `${firstWindow} this text must not affect the embedding`,
+        'DOCUMENT',
+        'SAP_GXY.20250407'
+      );
+
+      assert.strictEqual(withAdditionalText, truncated);
+    });
+
     test('different inputs produce different outputs', async () => {
       const e1 = vector_embedding('hello world', 'DOCUMENT', 'SAP_GXY.20250407');
       const e2 = vector_embedding('goodbye world', 'DOCUMENT', 'SAP_GXY.20250407');


### PR DESCRIPTION
## Summary

- embed only the first tokenizer/model input window
- remove averaging across independently embedded chunks
- keep `[CLS]` and `[SEP]` within the model's input limit
- document that long documents should be split and stored as multiple vectors above `VECTOR_EMBEDDING`

This addresses the averaging concern raised in #53: averaging sentence embeddings does not produce the embedding of the combined text and becomes increasingly misleading for smaller model windows.

## Validation

- tokenizer and model-download unit tests pass
- real MiniLM test confirms that appending text beyond the first input window does not change the embedding
- ESLint, Prettier, and `git diff --check` pass

## Stack

Targets `AISQLiteService` so merging this PR updates #53 directly.
