### PR TITLE
ci: install CDS 9-compatible SQLite without an override

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -73,7 +73,7 @@ runs:
       if: inputs.CDS_VERSION == '9'
       shell: bash
       run: |
-        npm pkg set "overrides.@cap-js/sqlite=^2"
+        npm pkg set "devDependencies.@cap-js/sqlite=^2"
         npm pkg set "overrides.@cap-js/hana=^2"
         npm pkg set "overrides.@sap/cds-mtxs=^3"
         npm pkg set "devDependencies.@sap/cds=^9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Pin CDS 9 compatible stack
         if: matrix.cds-version == '9'
         run: |
-          npm pkg set "overrides.@cap-js/sqlite=^2"
+          npm pkg set "devDependencies.@cap-js/sqlite=^2"
           npm pkg set "overrides.@cap-js/hana=^2"
           npm pkg set "overrides.@sap/cds-mtxs=^3"
           npm pkg set "devDependencies.@sap/cds=^9"


### PR DESCRIPTION
## Summary

- install `@cap-js/sqlite@^2` as a root development dependency in the CDS 9 test matrix
- stop overriding the package's direct `@cap-js/sqlite` dependency

## Why

PR #53 declares `@cap-js/sqlite` as an optional peer with the broad `>=2` compatibility range. npm rejects the current root override with `EOVERRIDE` because it conflicts with that direct dependency. Selecting v2 through `devDependencies` keeps the CDS 9 matrix pinned without narrowing the package's peer range or breaking the latest-CDS/v3 matrix.

This must land on `main` first because the CI workflow uses `pull_request_target`, and the integration job loads its composite action from `main`.

Unblocks #53.
