### PR TITLE
chore: prep v1.2.0

### DIFF
--- a/.docs/vector-embeddings.md
+++ b/.docs/vector-embeddings.md
@@ -132,7 +132,7 @@ Use the HANA-shaped function from CQL or SQL:
 
 ```js
 SELECT.from('Books').columns`
-  VECTOR_EMBEDDING(title, 'DOCUMENT', 'local') as embedding
+  VECTOR_EMBEDDING(title, 'DOCUMENT', 'SAP_GXY.20250407') as embedding
 `;
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,8 @@
 
 ### Added
 
-- **Experimental:** Extend the standard `sqlite` service and its `sqlite:memory` preset for local CAP development with `VECTOR_EMBEDDING`, model provisioning tooling, and `sentence-transformers/all-MiniLM-L6-v2` as a replaceable default that may change while the feature remains experimental.
+- **Experimental:** Extend the standard `sqlite` service and its `sqlite:memory` preset for local CAP development with `VECTOR_EMBEDDING`, model provisioning tooling, and `sentence-transformers/all-MiniLM-L6-v2` as a replaceable default that may change while the feature remains experimental. Local vector embeddings require `@sap/cds^10.1` and `@cap-js/sqlite^3.1`; the package's other capabilities continue to support `@sap/cds>=9`.
 - **Experimental:** Add local `SPARQL_EXECUTE` and `sparql_table` support through the optional `oxigraph` peer dependency.
-
-Local vector embeddings require `@sap/cds` `^10.1` and `@cap-js/sqlite` `^3.1`; the package's other capabilities continue to support `@sap/cds` 9.
 
 ## Version 1.1.0 - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.2.0 - tbd
+## Version 1.2.0 - 2026-09-07
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
    In another terminal:
 
    ```sh
-   curl "http://localhost:4004/odata/v4/search/searchBooks(phrase='seafaring%20adventure')"
+   curl "http://localhost:4004/odata/v4/search/searchBooks(phrase='a%20haunting%20poem%20about%20lost%20love')"
    ```
 
 On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. Embeddings are 384-dimensional vectors.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
    curl "http://localhost:4004/odata/v4/search/searchBooks(phrase='a%20haunting%20poem%20about%20lost%20love')"
    ```
 
-On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. The function returns the books ranked by relevance to the phrase.
+On the first start, `@cap-js/ai` warns if the configured model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. The function returns the books ranked by relevance to the phrase.
 
 The current default is [`sentence-transformers/all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2), chosen only as the most-downloaded reasonably small model matching the sentence-similarity task, ONNX format, and Apache-2.0 license. This is not a recommendation and may change while the feature is experimental — set `cds.requires.db.embedding.model` to pin it. Browse alternatives among [trending Apache-2.0 sentence-similarity models with ONNX artifacts](https://huggingface.co/models?pipeline_tag=sentence-similarity&library=onnx&license=license:apache-2.0&sort=trending), then validate your choice with the provided tooling.
 

--- a/README.md
+++ b/README.md
@@ -63,19 +63,7 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
 
    This requires `@sap/cds` `^10.1` and `@cap-js/sqlite` `^3.1` (the package's other capabilities still support `@sap/cds` 9). No configuration is needed: the standard `sqlite` and `sqlite:memory` databases pick up the local implementation automatically.
 
-2. Store an embedding of each book's description. Extend `Books` with a calculated element that is computed on write:
-
-   ```cds
-   using { sap.capire.bookshop.Books } from '@capire/bookshop';
-
-   extend Books with {
-     embedding : Vector = vector_embedding(descr, 'DOCUMENT', 'SAP_GXY.20250407') stored;
-   }
-   ```
-
-   The model name is ignored on SQLite — the locally configured model is used — and honored on SAP HANA, so the same definition runs unchanged on both.
-
-3. Expose the search as an OData function that ranks book descriptions by cosine similarity to an embedded search phrase:
+2. Expose the search as an OData function. It ranks books by the cosine similarity between an embedded search phrase and each book's embedded description:
 
    ```cds
    using { sap.capire.bookshop.Books } from '@capire/bookshop';
@@ -94,7 +82,8 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
    module.exports = class SearchService extends cds.ApplicationService { init() {
      this.on('searchBooks', ({ data: { phrase } }) =>
        SELECT.from('sap.capire.bookshop.Books')
-         .columns`title, cosine_similarity(embedding,
+         .columns`title, cosine_similarity(
+           vector_embedding(descr, 'DOCUMENT', 'SAP_GXY.20250407'),
            vector_embedding(${phrase}, 'QUERY', 'SAP_GXY.20250407')) as relevance`
          .orderBy`relevance desc`
      )
@@ -102,7 +91,9 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
    }}
    ```
 
-4. Run the app and call the function:
+   The model name is ignored on SQLite — the locally configured model is used — and honored on SAP HANA, so the same query runs unchanged on both. This embeds every book's description on each request; for repeated searches, persist the embeddings instead (see [Local vector embeddings](.docs/vector-embeddings.md)).
+
+3. Run the app and call the function:
 
    ```sh
    cds watch
@@ -114,7 +105,7 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
    curl "http://localhost:4004/odata/v4/search/searchBooks(phrase='a%20haunting%20poem%20about%20lost%20love')"
    ```
 
-On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. Embeddings are returned as a JSON-encoded vector.
+On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. The function returns the books ranked by relevance to the phrase.
 
 The current default is [`sentence-transformers/all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2), chosen only as the most-downloaded reasonably small model matching the sentence-similarity task, ONNX format, and Apache-2.0 license. This is not a recommendation and may change while the feature is experimental — set `cds.requires.db.embedding.model` to pin it. Browse alternatives among [trending Apache-2.0 sentence-similarity models with ONNX artifacts](https://huggingface.co/models?pipeline_tag=sentence-similarity&library=onnx&license=license:apache-2.0&sort=trending), then validate your choice with the provided tooling.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
 > [!WARNING]
 > The SQLite extensions, local vector embeddings, local model management, and the related tooling are experimental facilities for local development. Breaking changes are expected, including changes caused by SQLite's synchronous function interface and by local model management. Use SAP HANA's vector engine for production vector workloads.
 
-Here is a complete Bookshop example.
+`@cap-js/ai` redirects the standard `sqlite` database so that `VECTOR_EMBEDDING` and the vector functions run locally against a real [ONNX](https://onnx.ai) model — no external service, and no code changes versus SAP HANA. This lets you develop and test semantic search on SQLite. The following searches [Bookshop](https://github.com/capire/bookshop)'s books by the meaning of their descriptions.
 
 1. Install the local-development dependencies:
 
@@ -61,55 +61,33 @@ Here is a complete Bookshop example.
      @huggingface/tokenizers@0.1.3 onnxruntime-node@1.20.1
    ```
 
-   Local vector embeddings require `@sap/cds` `^10.1` and `@cap-js/sqlite` `^3.1`; the package's other capabilities continue to support `@sap/cds` 9.
+   This requires `@sap/cds` `^10.1` and `@cap-js/sqlite` `^3.1` (the package's other capabilities still support `@sap/cds` 9). No configuration is needed: the standard `sqlite` and `sqlite:memory` databases pick up the local implementation automatically.
 
-2. Use the standard SQLite service. Most CAP projects already do this in development; an explicit configuration looks like this:
+2. Store an embedding of each book's description. Extend `Books` with a calculated element that is computed on write:
 
-   ```json
-   {
-     "cds": {
-       "requires": {
-         "db": {
-           "kind": "sqlite"
-         }
-       }
-     }
+   ```cds
+   using { sap.capire.bookshop.Books } from '@capire/bookshop';
+
+   extend Books with {
+     embedding : Vector = vector_embedding(descr, 'DOCUMENT', 'SAP_GXY.20250407') stored;
    }
    ```
 
-3. Add an embedding preview to the Bookshop service. In its service implementation, which imports `cds` from `@sap/cds`:
+   The model name is ignored on SQLite — the locally configured model is used — and honored on SAP HANA, so the same definition runs unchanged on both.
 
-   ```cds
-   function embedding(text : String) returns LargeString;
-   ```
+3. Search books by meaning. Embed a search phrase as a `QUERY` and rank descriptions by cosine similarity:
 
    ```js
-   this.on('embedding', async (req) => {
-     const [row] = await cds.db.run(
-       `SELECT VECTOR_EMBEDDING(?, 'DOCUMENT', 'local') AS embedding`,
-       [req.data.text]
-     );
-     return row.embedding;
-   });
+   const phrase = 'seafaring adventures on the high seas'
+   const books = await SELECT.from('sap.capire.bookshop.Books')
+     .columns`title, cosine_similarity(embedding,
+       vector_embedding(${phrase}, 'QUERY', 'SAP_GXY.20250407')) as relevance`
+     .orderBy`relevance desc`
    ```
 
-4. Start the application and call the function:
+On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. Embeddings are 384-dimensional vectors.
 
-   ```sh
-   cds w
-   ```
-
-   In another terminal:
-
-   ```sh
-   curl 'http://localhost:4004/odata/v4/catalog/embedding(text=%27A%20book%20about%20travel%27)'
-   ```
-
-`@cap-js/ai` redirects the standard `sqlite` implementation to add the local capabilities. With `@sap/cds` `^10.1`, the standard `sqlite:memory` preset inherits that implementation. The first start warns that the default model is missing, downloads it to `.cds/models`, and then initializes it. The response's `value` contains a JSON-encoded vector with 384 numbers. Later starts reuse the installed model.
-
-The current default is [`sentence-transformers/all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2). It was selected only because, at the time of selection, it was the most-downloaded reasonably small model matching the sentence-similarity task, ONNX format, and Apache-2.0 license filters below. This is not a recommendation, and the default may change at any time while this feature is experimental. Configure `cds.requires.db.embedding.model` explicitly if the choice must remain stable.
-
-Start model discovery with [trending Apache-2.0 sentence-similarity models that provide ONNX artifacts](https://huggingface.co/models?pipeline_tag=sentence-similarity&library=onnx&license=license:apache-2.0&sort=trending). These filters select a relevant task, a locally runnable format, and a permissive license, but they do not guarantee compatibility. Choose a model as big as necessary and as small as possible, then validate it with the provided tooling.
+The current default is [`sentence-transformers/all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2), chosen only as the most-downloaded reasonably small model matching the sentence-similarity task, ONNX format, and Apache-2.0 license. This is not a recommendation and may change while the feature is experimental — set `cds.requires.db.embedding.model` to pin it. Browse alternatives among [trending Apache-2.0 sentence-similarity models with ONNX artifacts](https://huggingface.co/models?pipeline_tag=sentence-similarity&library=onnx&license=license:apache-2.0&sort=trending), then validate your choice with the provided tooling.
 
 See [Choosing a model](.docs/model-selection.md) and [Local vector embeddings](.docs/vector-embeddings.md) for compatibility checks, explicit or shared provisioning, runtime behavior, and limitations.
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,43 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
 
    The model name is ignored on SQLite — the locally configured model is used — and honored on SAP HANA, so the same definition runs unchanged on both.
 
-3. Search books by meaning. Embed a search phrase as a `QUERY` and rank descriptions by cosine similarity:
+3. Expose the search as an OData function that ranks book descriptions by cosine similarity to an embedded search phrase:
+
+   ```cds
+   using { sap.capire.bookshop.Books } from '@capire/bookshop';
+
+   service SearchService {
+     function searchBooks(phrase : String) returns array of {
+       title : String;
+       relevance : Double;
+     };
+   }
+   ```
 
    ```js
-   const phrase = 'seafaring adventures on the high seas'
-   const books = await SELECT.from('sap.capire.bookshop.Books')
-     .columns`title, cosine_similarity(embedding,
-       vector_embedding(${phrase}, 'QUERY', 'SAP_GXY.20250407')) as relevance`
-     .orderBy`relevance desc`
+   const cds = require('@sap/cds')
+
+   module.exports = class SearchService extends cds.ApplicationService { init() {
+     this.on('searchBooks', ({ data: { phrase } }) =>
+       SELECT.from('sap.capire.bookshop.Books')
+         .columns`title, cosine_similarity(embedding,
+           vector_embedding(${phrase}, 'QUERY', 'SAP_GXY.20250407')) as relevance`
+         .orderBy`relevance desc`
+     )
+     return super.init()
+   }}
+   ```
+
+4. Run the app and call the function:
+
+   ```sh
+   cds watch
+   ```
+
+   In another terminal:
+
+   ```sh
+   curl "http://localhost:4004/odata/v4/search/searchBooks(phrase='seafaring%20adventure')"
    ```
 
 On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. Embeddings are 384-dimensional vectors.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See [SAP AI Core integration](.docs/ai-core.md) for setup, supported queries, he
    curl "http://localhost:4004/odata/v4/search/searchBooks(phrase='a%20haunting%20poem%20about%20lost%20love')"
    ```
 
-On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. Embeddings are 384-dimensional vectors.
+On the first start, `@cap-js/ai` warns that the default model is missing, downloads it to `.cds/models`, and initializes it; later starts reuse it. Embeddings are returned as a JSON-encoded vector.
 
 The current default is [`sentence-transformers/all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2), chosen only as the most-downloaded reasonably small model matching the sentence-similarity task, ONNX format, and Apache-2.0 license. This is not a recommendation and may change while the feature is experimental — set `cds.requires.db.embedding.model` to pin it. Browse alternatives among [trending Apache-2.0 sentence-similarity models with ONNX artifacts](https://huggingface.co/models?pipeline_tag=sentence-similarity&library=onnx&license=license:apache-2.0&sort=trending), then validate your choice with the provided tooling.
 

--- a/lib/knowledge-graph/triplestore.js
+++ b/lib/knowledge-graph/triplestore.js
@@ -1,8 +1,14 @@
+import { createRequire } from 'node:module';
+
+// oxigraph is an optional native dependency, only needed for the knowledge-graph
+// feature. Load it synchronously via createRequire: a top-level `await import`
+// would make this module (and every module importing it, including the SQLite
+// service) an async ESM graph, which cannot be require()d by CommonJS consumers.
 let oxigraph;
 try {
-  oxigraph = await import('oxigraph');
+  oxigraph = createRequire(import.meta.url)('oxigraph');
 } catch (err) {
-  if (err.code !== 'ERR_MODULE_NOT_FOUND') throw err;
+  if (err.code !== 'MODULE_NOT_FOUND') throw err;
 }
 
 import { pipeline } from 'node:stream/promises';

--- a/lib/sqlite/AISQLiteService.js
+++ b/lib/sqlite/AISQLiteService.js
@@ -1,12 +1,21 @@
 import cds from '@sap/cds';
+import { createRequire } from 'node:module';
 import { createEmbeddingRuntime } from '../vector_embedding/embedding.js';
 import TripleStore from '../knowledge-graph/triplestore.js';
 import { loadSQLiteService } from './load-sqlite.js';
+import { readPackageVersion, validateAISQLiteServiceVersions } from './version-check.js';
 
+const require = createRequire(import.meta.url);
 const SQLiteService = loadSQLiteService();
 
 const LOG = cds.log('@cap-js/ai');
 const $tripleStore = Symbol('tripleStore');
+
+validateAISQLiteServiceVersions({
+  cdsVersion: cds.version,
+  sqliteVersion: readPackageVersion('@cap-js/sqlite', require),
+  warn: (message) => LOG.warn(message)
+});
 
 export default class AISQLiteService extends SQLiteService {
   _tripleStores = new Map();

--- a/lib/sqlite/version-check.js
+++ b/lib/sqlite/version-check.js
@@ -1,0 +1,42 @@
+const REQUIREMENTS = {
+  cds: { packageName: '@sap/cds', range: '^10.1', major: 10, minor: 1 },
+  sqlite: { packageName: '@cap-js/sqlite', range: '^3.1', major: 3, minor: 1 }
+};
+
+function satisfiesCaret(version, { major, minor }) {
+  if (typeof version !== 'string') return false;
+
+  const match = /^v?(\d+)\.(\d+)(?:\.(\d+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(version);
+  if (!match) return false;
+
+  const actualMajor = Number(match[1]);
+  const actualMinor = Number(match[2]);
+  return actualMajor === major && actualMinor >= minor;
+}
+
+function readPackageVersion(packageName, requireModule) {
+  try {
+    return requireModule(`${packageName}/package.json`)?.version;
+  } catch {
+    return undefined;
+  }
+}
+
+function validateAISQLiteServiceVersions({ cdsVersion, sqliteVersion, warn = () => {} }) {
+  const cdsSupported = satisfiesCaret(cdsVersion, REQUIREMENTS.cds);
+  const sqliteSupported = satisfiesCaret(sqliteVersion, REQUIREMENTS.sqlite);
+  if (cdsSupported && sqliteSupported) return true;
+
+  const foundCds = cdsVersion ?? 'unknown';
+  const foundSQLite = sqliteVersion ?? 'unknown';
+  warn(
+    `AISQLiteService requires ${REQUIREMENTS.cds.packageName} ${REQUIREMENTS.cds.range} and ` +
+      `${REQUIREMENTS.sqlite.packageName} ${REQUIREMENTS.sqlite.range}; found ` +
+      `${REQUIREMENTS.cds.packageName} ${foundCds} and ` +
+      `${REQUIREMENTS.sqlite.packageName} ${foundSQLite}. ` +
+      'Local SQLite AI features may not work correctly.'
+  );
+  return false;
+}
+
+export { readPackageVersion, validateAISQLiteServiceVersions };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/ai",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CAP cds-plugin for AI capabilities",
   "repository": "cap-js/ai",
   "type": "module",

--- a/tests/integration/mtx-setup.js
+++ b/tests/integration/mtx-setup.js
@@ -56,7 +56,17 @@ export function cleanDbFiles() {
  */
 export function startSidecar() {
   return new Promise((resolve, reject) => {
-    const sidecarEnv = { ...process.env, FORCE_COLOR: '0' };
+    const sidecarEnv = {
+      ...process.env,
+      FORCE_COLOR: '0',
+      // Force sqlite for tenant DBs. The [mtx-sidecar] profile's [production]
+      // preset sets db.kind='hana', and the presence of VCAP_SERVICES (below,
+      // ai-core is kept) activates that profile in CI. cds-mtxs' hana plugin
+      // throws at load ("No Service Manager credentials found") when kind is
+      // 'hana' without an SM binding — so pin the kind, not just the binding.
+      CDS_REQUIRES_DB_KIND: 'sqlite',
+      CDS_REQUIRES_DB_CREDENTIALS_URL: 'db.sqlite'
+    };
     // Strip HANA DB binding — sidecar uses sqlite for local tenant DBs.
     // Keep ai-core binding so the subscribe handler can create resource groups.
     if (sidecarEnv.VCAP_SERVICES) {

--- a/tests/sqlite-version.test.js
+++ b/tests/sqlite-version.test.js
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  readPackageVersion,
+  validateAISQLiteServiceVersions
+} from '../lib/sqlite/version-check.js';
+
+describe('AISQLiteService dependency versions', () => {
+  test('accepts versions within the supported ranges', () => {
+    const warnings = [];
+
+    assert.equal(
+      validateAISQLiteServiceVersions({
+        cdsVersion: '10.1.0',
+        sqliteVersion: '3.1.0',
+        warn: (message) => warnings.push(message)
+      }),
+      true
+    );
+    assert.equal(
+      validateAISQLiteServiceVersions({
+        cdsVersion: '10.9.4',
+        sqliteVersion: '3.8.2',
+        warn: (message) => warnings.push(message)
+      }),
+      true
+    );
+    assert.deepEqual(warnings, []);
+  });
+
+  test('warns for versions outside the supported ranges', () => {
+    const warnings = [];
+
+    assert.equal(
+      validateAISQLiteServiceVersions({
+        cdsVersion: '10.0.6',
+        sqliteVersion: '3.0.2',
+        warn: (message) => warnings.push(message)
+      }),
+      false
+    );
+    assert.equal(
+      validateAISQLiteServiceVersions({
+        cdsVersion: '11.0.0',
+        sqliteVersion: '4.0.0',
+        warn: (message) => warnings.push(message)
+      }),
+      false
+    );
+
+    for (const warning of warnings) {
+      assert.match(warning, /@sap\/cds \^10\.1/);
+      assert.match(warning, /@cap-js\/sqlite \^3\.1/);
+      assert.match(warning, /Local SQLite AI features may not work correctly/);
+    }
+    assert.match(warnings[0], /@sap\/cds 10\.0\.6/);
+    assert.match(warnings[0], /@cap-js\/sqlite 3\.0\.2/);
+    assert.match(warnings[1], /@sap\/cds 11\.0\.0/);
+    assert.match(warnings[1], /@cap-js\/sqlite 4\.0\.0/);
+  });
+
+  test('warns when an installed version cannot be determined', () => {
+    const warnings = [];
+
+    assert.equal(
+      validateAISQLiteServiceVersions({
+        cdsVersion: undefined,
+        sqliteVersion: 'not-semver',
+        warn: (message) => warnings.push(message)
+      }),
+      false
+    );
+    assert.match(warnings[0], /@sap\/cds unknown/);
+    assert.match(warnings[0], /@cap-js\/sqlite not-semver/);
+  });
+
+  test('reads package versions without exposing lookup failures', () => {
+    assert.equal(
+      readPackageVersion('@cap-js/sqlite', (specifier) => {
+        assert.equal(specifier, '@cap-js/sqlite/package.json');
+        return { version: '3.1.4' };
+      }),
+      '3.1.4'
+    );
+    assert.equal(
+      readPackageVersion('@cap-js/sqlite', () => {
+        throw new Error('package metadata is not exported');
+      }),
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
### chore: Bump version to 1.2.0

Version bump for the `@cap-js/ai` package from `1.1.0` to `1.2.0` in preparation for the next release.

**Category:** Chore

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.7`

- Correlation ID: `c6048050-a634-11f1-8dcd-a5f93d213162`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
